### PR TITLE
Adds support for x86 Windows 7 images

### DIFF
--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -12,6 +12,7 @@ import tempfile
 from vmcloak.dependencies import Python27
 from vmcloak.winxp import WindowsXP
 from vmcloak.win7 import Windows7
+from vmcloak.win7 import Windows7x64
 from vmcloak.repository import image_path, Session, Image
 from vmcloak.vm import VirtualBox
 
@@ -60,16 +61,17 @@ def main():
         h = WindowsXP()
         osversion = "winxp"
         ramsize = 1024
-    elif args.win7 or args.win7x64:
+    if args.win7:
         h = Windows7()
+        ramsize = 1024
+        osversion = "win7"
+    elif args.x64 or args.win7x64:
+        h = Windows7x86()
         ramsize = 2048
-        if args.x64 or args.win7x64:
-            osversion = "win7x64"
-            args.x64 = True
-        else:
-            osversion = "win7"
+        args.x64 = True
+        
     else:
-        log.error("Please provide either --winxp or --win7.")
+        log.error("Please provide either --winxp or --win7 or --win7xq64.")
         exit(1)
 
     if not os.path.isdir(args.iso_mount or h.mount) or \

--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -71,7 +71,7 @@ def main():
         args.x64 = True
         
     else:
-        log.error("Please provide either --winxp or --win7 or --win7xq64.")
+        log.error("Please provide either --winxp or --win7 or --win7x64.")
         exit(1)
 
     if not os.path.isdir(args.iso_mount or h.mount) or \

--- a/vmcloak/data/win7/autounattend.xml
+++ b/vmcloak/data/win7/autounattend.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="oobeSystem">
-        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>0409:00020409</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
             <UILanguageFallback>en-US</UILanguageFallback>
             <UserLocale>en-US</UserLocale>
         </component>
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <TimeZone>W. Europe Standard Time</TimeZone>
             <OOBE>
                 <HideEULAPage>true</HideEULAPage>
@@ -46,7 +46,7 @@
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>1</Order>
@@ -60,17 +60,17 @@
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>
-        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
-        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <ComputerName>@COMPUTERNAME@</ComputerName>
             <ShowWindowsLive>false</ShowWindowsLive>
         </component>
-        <component name="Security-Malware-Windows-Defender" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Security-Malware-Windows-Defender" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DisableAntiSpyware>true</DisableAntiSpyware>
         </component>
-        <component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Networking-MPSSVC-Svc" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DisableStatefulFTP>true</DisableStatefulFTP>
             <DisableStatefulPPTP>true</DisableStatefulPPTP>
             <DomainProfile_EnableFirewall>false</DomainProfile_EnableFirewall>
@@ -79,7 +79,7 @@
         </component>
     </settings>
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>0409:00020409</InputLocale>
             <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
@@ -89,7 +89,7 @@
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
         </component>
-        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <Diagnostics>
                 <OptIn>false</OptIn>
             </Diagnostics>
@@ -157,7 +157,7 @@
                 </ProductKey>
             </UserData>
         </component>
-        <component name="Microsoft-Windows-TCPIP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <component name="Microsoft-Windows-TCPIP" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <Interfaces>
                 <Interface wcm:action="add">
                     <Identifier>Local Area Connection</Identifier>

--- a/vmcloak/win7.py
+++ b/vmcloak/win7.py
@@ -33,6 +33,84 @@ class Windows7(OperatingSystem):
             'USERNAME': random_string(8, 12),
             'PASSWORD': random_string(8, 16),
             "PRODUCT": product.upper(),
+            "ARCH": 'x86',
+        }
+
+        buf = open(os.path.join(self.path, 'autounattend.xml'), 'rb').read()
+        for key, value in values.items():
+            buf = buf.replace('@%s@' % key, value)
+
+        return buf
+
+    def isofiles(self, outdir, tmp_dir=None):
+        products = []
+
+        product_ini = os.path.join(outdir, "sources", "product.ini")
+        mode, conf = ini_read(product_ini)
+
+        for line in conf.get("BuildInfo", []):
+            if "=" not in line:
+                continue
+
+            key, value = line.split("=", 1)
+            if key != "staged":
+                continue
+
+            for product in value.split(","):
+                products.append(product.lower())
+
+            break
+
+        for preference in self.preference:
+            if preference in products:
+                product = preference
+                break
+        else:
+            if products:
+                product = products[0]
+            else:
+                product = self.preference[0]
+
+        if self.s.product and self.s.product.lower() not in self.preference:
+            log.error("The product version of Windows 7 that was specified "
+                      "on the command-line is not known by us, ignoring it.")
+            self.s.product = None
+
+        with open(os.path.join(outdir, 'autounattend.xml'), 'wb') as f:
+            f.write(self._autounattend_xml(self.s.product or product))
+
+    def set_serial_key(self, serial_key):
+        if serial_key and not valid_serial_key(serial_key):
+            log.error('The provided serial key has an incorrect encoding.')
+            log.info('Example encoding, AAAAA-BBBBB-CCCCC-DDDDD-EEEEE.')
+            return False
+
+        # https://technet.microsoft.com/en-us/library/jj612867.aspx
+        self.serial_key = serial_key or '33PXH-7Y6KF-2VJC9-XBBR8-HVTHH'
+        return True
+
+class Windows7x86(OperatingSystem):
+    name = 'win7'
+    service_pack = 2
+    mount = '/mnt/win7'
+    nictype = '82540EM'
+    osdir = os.path.join('sources', '$oem$', '$1')
+    genisoargs = [
+        '-no-emul-boot', '-iso-level', '2', '-udf', '-J', '-l', '-D', '-N',
+        '-joliet-long', '-relaxed-filenames',
+    ]
+
+    # List of preferences when multiple Windows 7 types are available.
+    preference = "professional", "homepremium", "ultimate", "homebasic"
+
+    def _autounattend_xml(self, product):
+        values = {
+            'PRODUCTKEY': self.serial_key,
+            'COMPUTERNAME': random_string(8, 16),
+            'USERNAME': random_string(8, 12),
+            'PASSWORD': random_string(8, 16),
+            "PRODUCT": product.upper(),
+            "ARCH": 'amd64',
         }
 
         buf = open(os.path.join(self.path, 'autounattend.xml'), 'rb').read()

--- a/vmcloak/win7.py
+++ b/vmcloak/win7.py
@@ -89,7 +89,7 @@ class Windows7(OperatingSystem):
         self.serial_key = serial_key or '33PXH-7Y6KF-2VJC9-XBBR8-HVTHH'
         return True
 
-class Windows7x86(OperatingSystem):
+class Windows7x64(OperatingSystem):
     name = 'win7'
     service_pack = 2
     mount = '/mnt/win7'

--- a/vmcloak/win7.py
+++ b/vmcloak/win7.py
@@ -29,7 +29,7 @@ class Windows7(OperatingSystem):
     def _autounattend_xml(self, product):
         values = {
             'PRODUCTKEY': self.serial_key,
-            'COMPUTERNAME': random_string(8, 16),
+            'COMPUTERNAME': random_string(8, 14),
             'USERNAME': random_string(8, 12),
             'PASSWORD': random_string(8, 16),
             "PRODUCT": product.upper(),
@@ -106,7 +106,7 @@ class Windows7x64(OperatingSystem):
     def _autounattend_xml(self, product):
         values = {
             'PRODUCTKEY': self.serial_key,
-            'COMPUTERNAME': random_string(8, 16),
+            'COMPUTERNAME': random_string(8, 14),
             'USERNAME': random_string(8, 12),
             'PASSWORD': random_string(8, 16),
             "PRODUCT": product.upper(),


### PR DESCRIPTION
--win7 now properly works for x86 versions of windows and --win7x64 works for x64 versions.

Split Windows into two classes and slightly modified the xml file to accept the arch change between the two classes.