### PR TITLE
fix crash with Virtualbox 5.0.20 when iso is still locked

### DIFF
--- a/vmcloak/abstract.py
+++ b/vmcloak/abstract.py
@@ -318,6 +318,12 @@ class Dependency(object):
                            "Windows\\CurrentVersion\\Policies\\Explorer "
                            "/v NoDriveTypeAutoRun /t REG_DWORD /d 177")
 
+        """Disables Autorun for Windows 7 """
+        if self.h.name == "win7" or self.h.name == "win7x64":
+            self.a.execute("reg add HKEY_LOCAL_MACHINE\\Software\\Microsoft\\"
+                           "Windows\\CurrentVersion\\Policies\\Explorer "
+                           "/v NoDriveTypeAutoRun /t REG_DWORD /d 255")
+            
     def upload_dependency(self, filepath):
         """Upload this dependency to the specified filepath."""
         self.a.upload(filepath, open(self.filepath, "rb"))

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -132,6 +132,7 @@ class VirtualBox(Machinery):
                    type_='dvddrive', port=1, device=0, medium=iso_path)
 
     def detach_iso(self):
+        time.sleep(1)
         self._call('storageattach', self.name, storagectl='IDE',
                    type_='dvddrive', port=1, device=0, medium='emptydrive')
 


### PR DESCRIPTION
Bumped into something like that while deploying vm-s with Virtualbox 5.0.20

`Warning: creating filesystem that does not conform to ISO-9660.
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
VBoxManage: error: Could not find a controller named 'IDE'
ERROR:vmcloak.vm:[-] Error running command: Command '['/usr/bin/VBoxManage', 'storageattach', 'vm-win7-64bit-1', '--storagectl', 'IDE', '--device', '0', '--type', 'dvddrive', '--medium', 'emptydrive', '--port', '1']' returned non-zero exit status 1
Traceback (most recent call last):
  File "/usr/local/bin/vmcloak-init", line 4, in <module>
    __import__('pkg_resources').run_script('VMCloak==0.3.10', 'vmcloak-init')
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 719, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1504, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/VMCloak-0.3.10-py2.7.egg/EGG-INFO/scripts/vmcloak-init", line 159, in <module>
    main()
  File "/usr/local/lib/python2.7/dist-packages/VMCloak-0.3.10-py2.7.egg/EGG-INFO/scripts/vmcloak-init", line 143, in main
    m.detach_iso()
  File "/usr/local/lib/python2.7/dist-packages/VMCloak-0.3.10-py2.7.egg/vmcloak/vm.py", line 136, in detach_iso
    type_='dvddrive', port=1, device=0, medium='emptydrive')
  File "/usr/local/lib/python2.7/dist-packages/VMCloak-0.3.10-py2.7.egg/vmcloak/vm.py", line 35, in _call
    raise CommandError
vmcloak.exceptions.CommandError`

running command via command line worked fine as lock was dropped by then.

version
`ii  virtualbox-5.0                       5.0.20-106931~Ubuntu~trusty             amd64        Oracle VM VirtualBox`

this sleepy patch fixes this behaviour