### PR TITLE
make ramsize dynamic for vmcloak-init

### DIFF
--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -37,6 +37,7 @@ def main():
     parser.add_argument("--gateway", type=str, default="192.168.56.1", help="Guest IP address.")
     parser.add_argument("--dns", type=str, default="8.8.8.8", help="DNS Server.")
     parser.add_argument("--cpus", type=int, default=1, help="CPU count.")
+    parser.add_argument("--ramsize", type=int, default=1024, help="Memory size")
     parser.add_argument("--tempdir", type=str, default=tempfile.gettempdir(), help="Temporary directory to build the ISO file.")
     parser.add_argument("--resolution", type=str, default="1024x768", help="Screen resolution.")
     parser.add_argument("--vm-visible", action="store_true", help="Start the Virtual Machine in GUI mode.")
@@ -57,17 +58,18 @@ def main():
         log.error("Only the VirtualBox Machinery is supported at this point.")
         exit(1)
 
+	ramsize = args.ramsize
+
     if args.winxp:
         h = WindowsXP()
         osversion = "winxp"
-        ramsize = 1024
     if args.win7:
         h = Windows7()
-        ramsize = 1024
         osversion = "win7"
     elif args.x64 or args.win7x64:
         h = Windows7x64()
-        ramsize = 2048
+		if ramsize == 1024:
+       		ramsize = 2048
         args.x64 = True
         osversion = "win7"
         

--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -68,8 +68,8 @@ def main():
         osversion = "win7"
     elif args.x64 or args.win7x64:
         h = Windows7x64()
-		if ramsize == 1024:
-       		ramsize = 2048
+        if ramsize == 1024:
+           ramsize = 2048
         args.x64 = True
         osversion = "win7"
         

--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -37,7 +37,7 @@ def main():
     parser.add_argument("--gateway", type=str, default="192.168.56.1", help="Guest IP address.")
     parser.add_argument("--dns", type=str, default="8.8.8.8", help="DNS Server.")
     parser.add_argument("--cpus", type=int, default=1, help="CPU count.")
-    parser.add_argument("--ramsize", type=int, default=1024, help="Memory size")
+    parser.add_argument("--ramsize", type=int, help="Memory size")
     parser.add_argument("--tempdir", type=str, default=tempfile.gettempdir(), help="Temporary directory to build the ISO file.")
     parser.add_argument("--resolution", type=str, default="1024x768", help="Screen resolution.")
     parser.add_argument("--vm-visible", action="store_true", help="Start the Virtual Machine in GUI mode.")
@@ -58,24 +58,26 @@ def main():
         log.error("Only the VirtualBox Machinery is supported at this point.")
         exit(1)
 
-    ramsize = args.ramsize
-
     if args.winxp:
         h = WindowsXP()
         osversion = "winxp"
+        ramsize = 1024
     if args.win7:
         h = Windows7()
+        ramsize = 1024
         osversion = "win7"
     elif args.x64 or args.win7x64:
         h = Windows7x64()
-        if ramsize == 1024:
-           ramsize = 2048
+        ramsize = 2048
         args.x64 = True
         osversion = "win7"
         
     else:
         log.error("Please provide either --winxp or --win7 or --win7x64.")
         exit(1)
+
+    if args.ramsize is not None:
+        ramsize = args.ramsize
 
     if not os.path.isdir(args.iso_mount or h.mount) or \
             not os.listdir(args.iso_mount or h.mount):

--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -58,7 +58,7 @@ def main():
         log.error("Only the VirtualBox Machinery is supported at this point.")
         exit(1)
 
-	ramsize = args.ramsize
+    ramsize = args.ramsize
 
     if args.winxp:
         h = WindowsXP()


### PR DESCRIPTION
This patch makes ramsize dynamic for vmcloak-init. Default override still remains from 1024 to 2048 on win7x64