### PR TITLE
fix win7 profile and crash during disk removal

### DIFF
--- a/bin/vmcloak-init
+++ b/bin/vmcloak-init
@@ -69,7 +69,7 @@ def main():
         h = Windows7x64()
         ramsize = 2048
         args.x64 = True
-        osversion = "win7"
+        osversion = "win7x64"
     else:
         log.error("Please provide either --winxp or --win7 or --win7x64.")
         exit(1)

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -120,6 +120,7 @@ class VirtualBox(Machinery):
         self._call('clonehd', hdd_inpath, hdd_outpath)
 
     def remove_hd(self):
+        time.sleep(1)
         self._call('storagectl', self.name, portcount=0,
                    name='IDE', remove=True)
 


### PR DESCRIPTION
first one fixes issue where 32 bits profile is pushed to 64bit win7
second one is similar to iso unmount ... python requests removal before lock is released and of course crashes :/  Managed to bump into that specially during modify. Seems like Virtualbox 5 needs slightly more breathing space