### PR TITLE
fix bootstrap.bat bug to have Python.exe in debug mode

### DIFF
--- a/vmcloak/data/bootstrap/bootstrap.bat
+++ b/vmcloak/data/bootstrap/bootstrap.bat
@@ -25,8 +25,7 @@ echo Installing the Agent.
 copy C:\vmcloak\agent.py C:\agent.py
 if "%DEBUG%" == "yes" (
     set PYTHON=C:\Python27\Python.exe
-)
-else (
+) else (
     set PYTHON=C:\Python27\Pythonw.exe
 )
 


### PR DESCRIPTION
so it seems that .bat cannot handle
`)

else (`

also related to #61 