### PR TITLE
don't force recommend by default

### DIFF
--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -292,10 +292,11 @@ def install(name, dependencies, vm_visible, recommended, debug):
     settings = {}
     deps = []
 
-    # Include all recommended dependencies.
-    for dependency in vmcloak.dependencies.plugins:
-        if dependency.recommended:
-            deps.append((dependency.name, dependency.default))
+    # Include all recommended dependencies when requested.
+    if recommend:
+        for dependency in vmcloak.dependencies.plugins:
+            if dependency.recommended:
+                deps.append((dependency.name, dependency.default))
 
     # Fetch the configuration settings off of the arguments.
     for dependency in dependencies:


### PR DESCRIPTION
if recommend flag is not set then currently it'll force installing the recommended packages even if you have like adobepdf version defined. Lets make it in a way that recommended packages will be pushed only when flag is set :)