### PR TITLE
fix register_cuckoo

### DIFF
--- a/vmcloak/misc.py
+++ b/vmcloak/misc.py
@@ -213,6 +213,7 @@ def register_cuckoo(hostonly_ip, tags, vmname, cuckoo_dirpath, rdp_port=None):
             "--platform", "windows",
             "--tags", tags or "",
             "--snapshot", "vmcloak",
+            "--options", "",
         ]
         subprocess.check_call(args)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Cuckoo requires that an options field (even if it is empty) is present