### PR TITLE
Enable VRDE and improvements to MS Office

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .gitignore
 docs/_build
 *.pyc
+
+build/
+dist/
+*.egg-info

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -42,6 +42,7 @@ class Agent(object):
 
     def execute(self, command, async=False):
         """Execute a command."""
+        log.debug("Excecuting command in VM: {}".format(command))
         if async:
             return self.post("/execute", command=command, async="true")
         else:

--- a/vmcloak/data/win10/autounattend.xml
+++ b/vmcloak/data/win10/autounattend.xml
@@ -82,12 +82,12 @@
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>0809:00000809</InputLocale>
-            <SystemLocale>en-GB</SystemLocale>
-            <UILanguage>en-GB</UILanguage>
-            <UILanguageFallback>en-GB</UILanguageFallback>
-            <UserLocale>en-GB</UserLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
             <SetupUILanguage>
-                <UILanguage>en-GB</UILanguage>
+                <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
         </component>
         <component name="Microsoft-Windows-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/vmcloak/dependencies/office.py
+++ b/vmcloak/dependencies/office.py
@@ -17,8 +17,17 @@ config = """
 </Configuration>
 """
 
+officever = {
+    "2016": "16.0",
+    "2013": "15.0",
+    "2010": "14.0",
+    "2007": "12.0",
+    "2003": "11.0",
+}
+
 class Office(Dependency):
     name = "office"
+    default = "2010"
 
     def init(self):
         self.isopath = None
@@ -60,6 +69,213 @@ class Office(Dependency):
         self.wait_process_exit("setup.exe")
 
         self.a.remove("C:\\config.xml")
+
+        # disable first use popup
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\General\" "
+            "/v ShownFirstRunOptin /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+
+        # dont report office binary files (pub/doc/xls/etc) to MS if validation failed
+        # https://blogs.technet.microsoft.com/office2010/2009/12/16/office-2010-file-validation/
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Security\\FileValidation\" "
+            "/v DisableReporting /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+
+        # Disable all privacy settings in all Office products
+        # https://social.technet.microsoft.com/Forums/office/en-US/0db3e246-04b6-4948-a98c-4459fb65b1f9/privacy-options-in-access-2010?forum=officeitproprevious
+        # https://msdn.microsoft.com/en-us/library/office/aa205294(v=office.11).aspx
+        # https://www.stigviewer.com/stig/microsoft_office_system_2007/2014-01-07/finding/V-17740
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Internet\" "
+            "/v UseOnlineContent /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Internet\" "
+            "/v UseOnlineAppDetect /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Internet\" "
+            "/v IDN_AlertOff /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Research\\Options\" "
+            "/v NoDiscovery /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Research\\Options\" "
+            "/v DiscoveryNeedOptIn /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+        # dont use online dictionaries
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Research\\Translation\" "
+            "/v UseOnline /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\" "
+            "/v UpdateReliabilityData /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # disable activeX warnings, disable AX safe mode
+        # https://www.greyhathacker.net/?p=948
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\Common\\Security\" "
+            "/v DisableAllActiveX /t REG_DWORD /d 0 /f"
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\Common\\Security\" "
+            "/v UFIControls /t REG_DWORD /d 1 /f"
+        )
+
+        # disable Protected View for all office products files
+        for product in ["Access", "Excel", "Outlook", "PowerPoint", "Publisher", "Word"]:
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\ProtectedView\" "
+                "/v DisableAttachmentsInPV /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\ProtectedView\" "
+                "/v DisableInternetFilesInPV /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\ProtectedView\" "
+                "/v DisableUnsafeLocationsInPV /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+
+        for product in ["Excel", "Powerpoint", "Word"]:
+            # disable DEP and macro warnings
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\" "
+                "/v EnableDEP /t REG_DWORD /d 0 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\" "
+                "/v VBAWarnings /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\" "
+                "/v AccessVBOM /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+
+            # Dont show warnings for files from the network
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\Trusted Locations\" "
+                "/v AllowNetworkLocations /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+
+        # Dont block older Word documents
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v OpenInProtectedView /t REG_DWORD /d 2 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v Word2Files /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v Word60Files /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v Word95Files /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # Dont block older Excel documents
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Excel\\Security\\FileBlock\" "
+            "/v OpenInProtectedView /t REG_DWORD /d 2 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL2Macros /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL2Worksheets /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL3Macros /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL3Worksheets /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL4Macros /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL4Workbooks /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL4Worksheets /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # Allow data connections without warnings in Excel
+        # https://www.experts-exchange.com/questions/28247804/Enable-Data-Connections-for-all-users.html
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Excel\\Security\" "
+            "/v DataConnectionWarnings /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # auto update workbook links
+        # https://support.microsoft.com/en-us/help/826921/how-to-control-the-startup-message-about-updating-linked-workbooks-in-excel
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Excel\\Security\" "
+            "/v WorkbookLinkWarnings /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # Enable macros in Outlook
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Outlook\\Security\" "
+            "/v Level /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+
+        # disable AV Notification in outlook
+        # https://www.slipstick.com/developer/change-programmatic-access-options/
+        self.a.execute(
+            "REG ADD \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Wow6432Node\\Microsoft\\Office\\{}\\Outlook\\Security\" "
+            "/v ObjectModelGuard /t REG_DWORD /d 2 /f".format(officever[self.version])
+        )
 
         if self.i.vm == "virtualbox":
             self.m.detach_iso()

--- a/vmcloak/dependencies/office.py
+++ b/vmcloak/dependencies/office.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 config = """
 <Configuration Product="ProPlus">
-    <Display Level="none" CompletionNotice="no" SuppressModal="yes" AcceptEula="yes" />
+    <Display Level="basic" CompletionNotice="no" SuppressModal="yes" AcceptEula="yes" />
     <PIDKEY Value="%(serial_key)s" />
     <Setting Id="AUTO_ACTIVATE" Value="%(activate)s" />
 </Configuration>

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -126,6 +126,7 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
+        vrde = True
         log.setLevel(logging.DEBUG)
 
     session = Session()
@@ -264,10 +265,12 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
 @click.argument("name")
 @click.argument("dependencies", nargs=-1)
 @click.option("--vm-visible", is_flag=True)
+@click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
 @click.option("-r", "--recommended", is_flag=True, help="Install recommended packages.")
 @click.option("-d", "--debug", is_flag=True, help="Install applications in debug mode.")
-def install(name, dependencies, vm_visible, recommended, debug):
+def install(name, dependencies, vm_visible, vrde, recommended, debug):
     if debug:
+        vrde = True
         log.setLevel(logging.DEBUG)
 
     session = Session()
@@ -286,6 +289,8 @@ def install(name, dependencies, vm_visible, recommended, debug):
     m, h = initvm(image)
 
     if image.vm == "virtualbox":
+        if vrde:
+            m.vrde()
         m.start_vm(visible=vm_visible)
 
     wait_for_host(image.ipaddr, image.port)
@@ -371,7 +376,13 @@ def install(name, dependencies, vm_visible, recommended, debug):
 @main.command()
 @click.argument("name")
 @click.option("--vm-visible", is_flag=True)
-def modify(name, vm_visible):
+@click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
+@click.option("-d", "--debug", is_flag=True, help="Install applications in debug mode.")
+def modify(name, vm_visible, vrde, debug):
+    if debug:
+        vrde = True
+        log.setLevel(logging.DEBUG)
+
     session = Session()
 
     image = session.query(Image).filter_by(name=name).first()
@@ -387,6 +398,8 @@ def modify(name, vm_visible):
 
     m, h = initvm(image)
 
+    if vrde:
+        m.vrde()
     m.start_vm(visible=vm_visible)
     wait_for_host(image.ipaddr, image.port)
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -116,12 +116,13 @@ def clone(name, outname):
 @click.option("--tempdir", default=iso_dst_path, help="Temporary directory to build the ISO file.")
 @click.option("--resolution", default="1024x768", help="Screen resolution.")
 @click.option("--vm-visible", is_flag=True, help="Start the Virtual Machine in GUI mode.")
+@click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
 @click.option("-d", "--debug", is_flag=True, help="Install Virtual Machine in debug mode.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
          win10x64, product, vm, iso_mount, serial_key, ip, port, adapter,
          netmask, gateway, dns, cpus, ramsize, vramsize, tempdir, resolution,
-         vm_visible, debug, verbose):
+         vm_visible, vrde, debug, verbose):
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
@@ -233,6 +234,9 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
         m.create_hd(hdd_path)
         m.attach_iso(iso_path)
         m.hostonly(nictype=h.nictype, adapter=adapter)
+
+        if vrde:
+            m.vrde()
 
         log.info("Starting the Virtual Machine %r to install Windows.", name)
         m.start_vm(visible=vm_visible)

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -221,7 +221,7 @@ class VirtualBox(Machinery):
     def mouse(self, type):
         return self._call("modifyvm", self.name, mouse=type)
 
-    def vrde(self, port, password):
+    def vrde(self, port=3389, password=""):
         return self._call("modifyvm", self.name, vrde="on", vrdeport=port,
                           vrdeproperty="VNCPassword=%s" % password)
 


### PR DESCRIPTION
One can now use the --vrde flag in vmcloak to enable the VirtualBox Remote Desktop Extension (VRDE) option in VirtualBox. This can be used to monitor the progress in the VM or to make modifications when running vmcloak modify.

Also added some registry settings for MS Office to improve malware analysis. Like enabling Macros without warnings and disabling ProtectedView mode for untrusted documents.