### PR TITLE
Improvements to dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .gitignore
 docs/_build
 *.pyc
+
+build/
+dist/
+*.egg-info

--- a/vmcloak/abstract.py
+++ b/vmcloak/abstract.py
@@ -445,7 +445,7 @@ class Dependency(object):
             if not os.path.exists(self.filepath):
                 continue
 
-            if self.exe["version"] == "latest":
+            if "version" in self.exe and self.exe["version"] == "latest":
                 log.info("Got latest version '{}' from '{}', no checksum available!".format(self.filename, url))
                 break
 

--- a/vmcloak/abstract.py
+++ b/vmcloak/abstract.py
@@ -435,7 +435,7 @@ class Dependency(object):
                 break
 
         self.filepath = os.path.join(deps_path, self.filename)
-        if (os.path.exists(self.filepath) and
+        if (os.path.exists(self.filepath) and "sha1" in self.exe and
                 sha1_file(self.filepath) == self.exe["sha1"]):
             return
 
@@ -444,6 +444,10 @@ class Dependency(object):
 
             if not os.path.exists(self.filepath):
                 continue
+
+            if self.exe["version"] == "latest":
+                log.info("Got latest version '{}' from '{}', no checksum available!".format(self.filename, url))
+                break
 
             if sha1_file(self.filepath) == self.exe["sha1"]:
                 log.info("Got file '{}' from '{}', with matching checksum.".format(self.filename, url))

--- a/vmcloak/abstract.py
+++ b/vmcloak/abstract.py
@@ -383,6 +383,7 @@ class Dependency(object):
         self.a = a
         self.i = i
         self.version = version or self.default
+        self.arch = h.arch
         self.settings = settings
         self.exe = None
         self.filename = None
@@ -403,7 +404,7 @@ class Dependency(object):
             if "version" in exe and exe["version"] != self.version:
                 continue
 
-            if "arch" in exe and exe["arch"] != h.arch:
+            if "arch" in exe and exe["arch"] != self.arch:
                 continue
 
             self.exe = exe

--- a/vmcloak/abstract.py
+++ b/vmcloak/abstract.py
@@ -416,8 +416,6 @@ class Dependency(object):
         # Download the dependency (if there is any to download).
         if self.exe:
             self.download()
-            if not os.path.exists(self.filepath):
-                raise DependencyError
 
         if self.check() is False:
             raise DependencyError
@@ -453,6 +451,9 @@ class Dependency(object):
             else:
                 log.warn("The checksum of '{}' from '{}' didn't match!".format(self.filename, url))
                 os.remove(self.filepath)
+
+        if not os.path.exists(self.filepath):
+            raise DependencyError
 
     def init(self):
         pass

--- a/vmcloak/agent.py
+++ b/vmcloak/agent.py
@@ -42,6 +42,7 @@ class Agent(object):
 
     def execute(self, command, async=False):
         """Execute a command."""
+        log.debug("Excecuting command in VM: {}".format(command))
         if async:
             return self.post("/execute", command=command, async="true")
         else:

--- a/vmcloak/data/bootstrap/bootstrap.bat
+++ b/vmcloak/data/bootstrap/bootstrap.bat
@@ -14,23 +14,23 @@ reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpd
 sc config wuauserv start= disabled
 net stop wuauserv
 
-echo Installing Python 2.7.6.
-start C:\vmcloak\python-2.7.6.msi
-C:\vmcloak\click.exe "Python 2.7.6 Setup" "Next >"
-C:\vmcloak\click.exe "Python 2.7.6 Setup" "Next >"
-C:\vmcloak\click.exe "Python 2.7.6 Setup" "Next >"
-C:\vmcloak\click.exe "Python 2.7.6 Setup" "Finish"
+echo Installing Python
+start C:\vmcloak\%PYTHONINSTALLER%
+C:\vmcloak\click.exe "%PYTHONWINDOW%" "Next >"
+C:\vmcloak\click.exe "%PYTHONWINDOW%" "Next >"
+C:\vmcloak\click.exe "%PYTHONWINDOW%" "Next >"
+C:\vmcloak\click.exe "%PYTHONWINDOW%" "Finish"
 
 echo Installing the Agent.
 copy C:\vmcloak\agent.py C:\agent.py
 if "%DEBUG%" == "yes" (
-    set PYTHON=C:\Python27\Python.exe
+    set PYTHON=%PYTHONPATH%\python.exe
 ) else (
-    set PYTHON=C:\Python27\Pythonw.exe
+    set PYTHON=%PYTHONPATH%\pythonw.exe
 )
 
 echo Setting the resolution.
-C:\Python27\Python.exe C:\vmcloak\resolution.py %RESO_WIDTH% %RESO_HEIGHT%
+%PYTHONPATH%\python.exe C:\vmcloak\resolution.py %RESO_WIDTH% %RESO_HEIGHT%
 
 reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Run /v Agent /t REG_SZ /d "%PYTHON% C:\agent.py 0.0.0.0 %AGENT_PORT%" /f
 

--- a/vmcloak/data/win10/autounattend.xml
+++ b/vmcloak/data/win10/autounattend.xml
@@ -82,12 +82,12 @@
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>0809:00000809</InputLocale>
-            <SystemLocale>en-GB</SystemLocale>
-            <UILanguage>en-GB</UILanguage>
-            <UILanguageFallback>en-GB</UILanguageFallback>
-            <UserLocale>en-GB</UserLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
             <SetupUILanguage>
-                <UILanguage>en-GB</UILanguage>
+                <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
         </component>
         <component name="Microsoft-Windows-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/vmcloak/data/win81/autounattend.xml
+++ b/vmcloak/data/win81/autounattend.xml
@@ -82,12 +82,12 @@
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>0809:00000809</InputLocale>
-            <SystemLocale>en-GB</SystemLocale>
-            <UILanguage>en-GB</UILanguage>
-            <UILanguageFallback>en-GB</UILanguageFallback>
-            <UserLocale>en-GB</UserLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
             <SetupUILanguage>
-                <UILanguage>en-GB</UILanguage>
+                <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
         </component>
         <component name="Microsoft-Windows-Setup" processorArchitecture="@ARCH@" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/vmcloak/dependencies/adobepdf.py
+++ b/vmcloak/dependencies/adobepdf.py
@@ -261,6 +261,14 @@ class AdobePdf(Dependency):
             "/v bUpdater /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
         )
 
+        # disable the sandboxing (protected mode)
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/protectedmode.html
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
+            "/v bProtectedMode /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
+        )
+
         # allow URL access
         self.a.execute(
             "reg add \"HKEY_CURRENT_USER\\Software\\Adobe\\"

--- a/vmcloak/dependencies/adobepdf.py
+++ b/vmcloak/dependencies/adobepdf.py
@@ -268,6 +268,12 @@ class AdobePdf(Dependency):
             "Policies\\Adobe\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
             "/v bProtectedMode /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
         )
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/protectedview.html
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
+            "/v iProtectedView /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
+        )
 
         # disable enchanced security
         # https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/enhanced.html

--- a/vmcloak/dependencies/adobepdf.py
+++ b/vmcloak/dependencies/adobepdf.py
@@ -115,6 +115,69 @@ class AdobePdf(Dependency):
             "filename": "AdbeRdr11010_en_US.exe",
         },
         {
+            "version": "11.0.11",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.11/misc/AdbeRdrUpd11011.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.11/misc/AdbeRdrUpd11011.msp",
+            ],
+            "sha1": "182eb5b4ca71e364f62e412cdaec65e7937417e4",
+            "filename": "AdbeRdrUpd11011.msp",
+        },
+        {
+            "version": "11.0.12",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.12/misc/AdbeRdrUpd11012.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.12/misc/AdbeRdrUpd11012.msp",
+            ],
+            "sha1": "c5a5f2727dd7dabe0fcf96ace644751ac27872e7",
+            "filename": "AdbeRdrUpd11012.msp",
+        },
+        {
+            "version": "11.0.13",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.13/misc/AdbeRdrUpd11013.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.13/misc/AdbeRdrUpd11013.msp",
+            ],
+            "sha1": "89317596ffe50e35c136ef204ac911cbf83b14d9",
+            "filename": "AdbeRdrUpd11013.msp",
+        },
+        {
+            "version": "11.0.14",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.14/misc/AdbeRdrUpd11014.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.14/misc/AdbeRdrUpd11014.msp",
+            ],
+            "sha1": "d7b990117d8a6bbc4380663b7090cd60d2103079",
+            "filename": "AdbeRdrUpd11014.msp",
+        },
+        {
+            "version": "11.0.16",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.16/misc/AdbeRdrUpd11016.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.16/misc/AdbeRdrUpd11016.msp",
+            ],
+            "sha1": "ca825c50ed96a2fec6056c94c1bb44eedbaed890",
+            "filename": "AdbeRdrUpd11016.msp",
+        },
+        {
+            "version": "11.0.17",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.17/misc/AdbeRdrUpd11017.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.17/misc/AdbeRdrUpd11017.msp",
+            ],
+            "sha1": "c5fe501856be635566e864fe76f6d6a7ff3874ca",
+            "filename": "AdbeRdrUpd11017.msp",
+        },
+        {
+            "version": "11.0.18",
+            "urls": [
+                "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.18/misc/AdbeRdrUpd11018.msp",
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.18/misc/AdbeRdrUpd11018.msp",
+            ],
+            "sha1": "420d64c064cd9904836a60066a222c64b0ea060e",
+            "filename": "AdbeRdrUpd11018.msp",
+        },
+        {
             "version": "11.0.19",
             "urls": [
                 "http://ardownload.adobe.com/pub/adobe/reader/win/11.x/11.0.19/misc/AdbeRdrUpd11019.msp",
@@ -123,6 +186,7 @@ class AdobePdf(Dependency):
             "sha1": "98fdf7a15fb2486ee7257767296d4f7a0a62ac92",
             "filename": "AdbeRdrUpd11019.msp",
         },
+
     ]
 
     def run(self):

--- a/vmcloak/dependencies/adobepdf.py
+++ b/vmcloak/dependencies/adobepdf.py
@@ -289,10 +289,40 @@ class AdobePdf(Dependency):
         )
 
         # allow URL access
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/PrefRef/Windows/FeatureLockdown.html
         self.a.execute(
             "reg add \"HKEY_CURRENT_USER\\Software\\Adobe\\"
             "Acrobat Reader\\%s.0\\TrustManager\\cDefaultLaunchURLPerms\" "
             "/v iURLPerms /t REG_DWORD /d 2 /f" % self.version.split(".")[0]
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\"
+            "FeatureLockDown\\cDefaultLaunchURLPerms\" "
+            "/v iUnknownURLPerms /t REG_DWORD /d 2 /f".format(self.version.split(".")[0])
+        )
+
+        # allow opening of all embedded files
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/PrefRef/Windows/Attachments.html
+        self.a.execute(
+            "reg delete \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\"
+            "FeatureLockDown\\cDefaultLaunchAttachmentPerms\" "
+            "/v tBuiltInPermList /f".format(self.version.split(".")[0])
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\"
+            "FeatureLockDown\\cDefaultLaunchAttachmentPerms\" "
+            "/v iUnlistedAttachmentTypePerm /t REG_DWORD /d 2 /f".format(self.version.split(".")[0])
+        )
+
+        # enable flash content
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/PrefRef/Windows/FeatureLockdown.html
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
+            "/v bEnableFlash /t REG_DWORD /d 1 /f".format(self.version.split(".")[0])
         )
 
         # FIXME: really needed ?

--- a/vmcloak/dependencies/adobepdf.py
+++ b/vmcloak/dependencies/adobepdf.py
@@ -269,6 +269,19 @@ class AdobePdf(Dependency):
             "/v bProtectedMode /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
         )
 
+        # disable enchanced security
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/enhanced.html
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
+            "/v bEnhancedSecurityStandalone /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Adobe\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
+            "/v bEnhancedSecurityInBrowser /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
+        )
+
         # allow URL access
         self.a.execute(
             "reg add \"HKEY_CURRENT_USER\\Software\\Adobe\\"

--- a/vmcloak/dependencies/adobepdf.py
+++ b/vmcloak/dependencies/adobepdf.py
@@ -92,7 +92,12 @@ class AdobePdf(Dependency):
         {
             "version": "11.0.10",
             "url": "https://cuckoo.sh/vmcloak/AdbeRdr11010_en_US.exe",
+            "urls": [
+                "ftp://ftp.adobe.com/pub/adobe/reader/win/11.x/11.0.10/en_US/AdbeRdr11010_en_US.exe",
+                "https://cuckoo.sh/vmcloak/AdbeRdr11010_en_US.exe",
+            ],
             "sha1": "98b2b838e6c4663fefdfd341dfdc596b1eff355c",
+            "filename": "AdbeRdr11010_en_US.exe",
         },
     ]
 
@@ -106,11 +111,6 @@ class AdobePdf(Dependency):
         self.a.remove("C:\\%s" % self.filename)
 
         # add needed registry keys to skip Licence Agreement
-        self.a.execute(
-            "reg add \"HKEY_LOCAL_MACHINE\\Software\\WOW6432Node\\"
-            "Adobe\\Acrobat Reader\\%s.0\\AdobeViewer\" " %
-            self.version.split(".")[0]
-        )
         self.a.execute(
             "reg add \"HKEY_LOCAL_MACHINE\\Software\\WOW6432Node\\"
             "Adobe\\Acrobat Reader\\%s.0\\AdobeViewer\" "
@@ -131,12 +131,15 @@ class AdobePdf(Dependency):
             self.version.split(".")[0]
         )
 
-        # allow URL access
+        # disable the updater completely
+        # https://www.adobe.com/devnet-docs/acrobatetk/tools/PrefRef/Windows/Updater-Win.html
         self.a.execute(
-            "reg add \"HKEY_CURRENT_USER\\Software\\Adobe\\"
-            "Acrobat Reader\\%s.0\\TrustManager\\cDefaultLaunchURLPerms\" " %
-            self.version.split(".")[0]
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Acrobat Reader\\{}.0\\FeatureLockDown\" "
+            "/v bUpdater /t REG_DWORD /d 0 /f".format(self.version.split(".")[0])
         )
+
+        # allow URL access
         self.a.execute(
             "reg add \"HKEY_CURRENT_USER\\Software\\Adobe\\"
             "Acrobat Reader\\%s.0\\TrustManager\\cDefaultLaunchURLPerms\" "

--- a/vmcloak/dependencies/chrome.py
+++ b/vmcloak/dependencies/chrome.py
@@ -6,16 +6,48 @@
 
 from vmcloak.abstract import Dependency
 
+
 class Chrome(Dependency):
     name = "chrome"
+    default = "46.0.2490.80"
     exes = [
         {
+            "version": "46.0.2490.80",
             "url": "https://cuckoo.sh/vmcloak/googlechromestandaloneenterprise.msi",
             "sha1": "a0ade494dda8911eeb68c9294c2dd0e3229d8f02",
+        },
+        {
+            "version": "latest",
+            "arch": "x86",
+            "urls": [
+                "https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi"
+            ],
+        },
+        {
+            "version": "latest",
+            "arch": "amd64",
+            "urls": [
+                "https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi"
+            ],
         },
     ]
 
     def run(self):
-        self.upload_dependency("C:\\googlechromestandaloneenterprise.msi")
-        self.a.execute("Msiexec /q /I C:\\googlechromestandaloneenterprise.msi")
-        self.a.remove("C:\\googlechromestandaloneenterprise.msi")
+        self.upload_dependency("C:\\%s" % self.filename)
+
+        # https://support.google.com/chrome/a/answer/6350036
+        # this is not working properly :(
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Google\\Update\" "
+            "/v UpdateDefault /t REG_DWORD /d 0 /f"
+        )
+
+        self.a.execute("msiexec /i C:\\%s /passive /norestart" % self.filename)
+        self.a.remove("C:\\%s" % self.filename)
+
+        # https://www.chromium.org/administrators/turning-off-auto-updates
+        # this is not working properly :(
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Google\\Update\" "
+            "/v AutoUpdateCheckPeriodMinutes /t REG_DWORD /d 0 /f"
+        )

--- a/vmcloak/dependencies/dotnet.py
+++ b/vmcloak/dependencies/dotnet.py
@@ -20,6 +20,13 @@ class DotNet(Dependency):
             "sha1": "58da3d74db353aad03588cbb5cea8234166d8b99",
         },
         {
+            "version": "4.5",
+            "urls": [
+                "https://download.microsoft.com/download/b/a/4/ba4a7e71-2906-4b2d-a0e1-80cf16844f5f/dotnetfx45_full_x86_x64.exe",
+            ],
+            "sha1": "b2ff712ca0947040ca0b8e9bd7436a3c3524bb5d",
+        },
+        {
             "version": "4.5.1",
             "urls": [
                 "https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe",
@@ -55,6 +62,13 @@ class DotNet(Dependency):
                 "https://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe",
             ],
             "sha1": "a70f856bda33d45ad0a8ad035f73092441715431",
+        },
+        {
+            "version": "4.7",
+            "urls": [
+                "https://download.microsoft.com/download/D/D/3/DD35CC25-6E9C-484B-A746-C5BE0C923290/NDP47-KB3186497-x86-x64-AllOS-ENU.exe",
+            ],
+            "sha1": "76054141a492ba307595250bda05ad4e0694cdc3",
         },
     ]
 

--- a/vmcloak/dependencies/dotnet.py
+++ b/vmcloak/dependencies/dotnet.py
@@ -4,6 +4,7 @@
 
 from vmcloak.abstract import Dependency
 
+
 class DotNet(Dependency):
     name = "dotnet"
     depends = "wic"
@@ -12,18 +13,48 @@ class DotNet(Dependency):
     exes = [
         {
             "version": "4.0",
-            "url": "https://cuckoo.sh/vmcloak/dotNetFx40_Full_x86_x64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe",
+                "https://cuckoo.sh/vmcloak/dotNetFx40_Full_x86_x64.exe",
+            ],
             "sha1": "58da3d74db353aad03588cbb5cea8234166d8b99",
         },
         {
             "version": "4.5.1",
-            "url": "https://cuckoo.sh/vmcloak/NDP451-KB2858728-x86-x64-AllOS-ENU.exe",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe",
+                "https://cuckoo.sh/vmcloak/NDP451-KB2858728-x86-x64-AllOS-ENU.exe",
+            ],
             "sha1": "5934dd101414bbc0b7f1ee2780d2fc8b9bec5c4d",
         },
         {
+            "version": "4.5.2",
+            "urls": [
+                "https://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe",
+            ],
+            "sha1": "89f86f9522dc7a8a965facce839abb790a285a63",
+        },
+        {
+            "version": "4.6",
+            "urls": [
+                "https://download.microsoft.com/download/C/3/A/C3A5200B-D33C-47E9-9D70-2F7C65DAAD94/NDP46-KB3045557-x86-x64-AllOS-ENU.exe",
+            ],
+            "sha1": "3049a85843eaf65e89e2336d5fe6e85e416797be",
+        },
+        {
             "version": "4.6.1",
-            "url": "https://cuckoo.sh/vmcloak/NDP461-KB3102436-x86-x64-AllOS-ENU.exe",
+            "urls": [
+                "https://download.microsoft.com/download/E/4/1/E4173890-A24A-4936-9FC9-AF930FE3FA40/NDP461-KB3102436-x86-x64-AllOS-ENU.exe",
+                "https://cuckoo.sh/vmcloak/NDP461-KB3102436-x86-x64-AllOS-ENU.exe",
+            ],
             "sha1": "83d048d171ff44a3cad9b422137656f585295866",
+        },
+        {
+            "version": "4.6.2",
+            "urls": [
+                "https://download.microsoft.com/download/F/9/4/F942F07D-F26F-4F30-B4E3-EBD54FABA377/NDP462-KB3151800-x86-x64-AllOS-ENU.exe",
+            ],
+            "sha1": "a70f856bda33d45ad0a8ad035f73092441715431",
         },
     ]
 

--- a/vmcloak/dependencies/flash.py
+++ b/vmcloak/dependencies/flash.py
@@ -20,6 +20,7 @@ class Flash(Dependency):
             "sha1": "906f920563403ace6dee9b0cff982ea02d4b5c06",
         },
         {
+            # Released 4/9/2013
             "version": "11.7.700.169",
             "url": "https://cuckoo.sh/vmcloak/flashplayer11_7r700_169_winax.msi",
             "sha1": "790b09c63c44f0eafd7151096bf58964857d3b17",
@@ -45,6 +46,7 @@ class Flash(Dependency):
             "sha1": "877c7e9a6de692bdef95a4f3cc22b9fb385db92e",
         },
         {
+            # Released 1/14/2014
             "version": "12.0.0.38",
             "url": "https://cuckoo.sh/vmcloak/flashplayer12_0r0_38_winax.msi",
             "sha1": "e44908c9a813876c1a332a174b2e3e9dff47a4ff",
@@ -105,9 +107,112 @@ class Flash(Dependency):
             "sha1": "1efef336190b021f6df3325f958f1698a91cce8c",
         },
         {
+            # Released 12/8/2015
             "version": "20.0.0.228",
             "url": "https://cuckoo.sh/vmcloak/flashplayer20_0d0_228_winax.msi",
             "sha1": "fa86f107111fc7def35742097bf0aa29c82d7638",
+        },
+        {
+            # Released 1/19/2016
+            "version": "20.0.0.286",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer20_0r0_286_winax.msi",
+            "sha1": "a1b73c662b7bce03ff2d8a729005e81036ea1a24",
+        },
+        {
+            # Released 2/9/2016
+            "version": "20.0.0.306",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer20_0r0_306_winax.msi",
+            "sha1": "68ae4277d68146749cb6cf597d3d6be07422c372",
+        },
+        {
+            # Released 3/10/2016
+            "version": "21.0.0.182",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer21_0r0_182_winax.msi",
+            "sha1": "717582fc7138c9cf4b3ec88413d38cddf8613d4c",
+        },
+        {
+            # Released 3/23/2016
+            "version": "21.0.0.197",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer21_0r0_197_winax.msi",
+            "sha1": "1e81a4617abcbb95ee6bf9250be5a205ce0d289b",
+        },
+        {
+            # Released 4/7/2016
+            "version": "21.0.0.213",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer21_0r0_213_winax.msi",
+            "sha1": "6d23ae1f12682b6baa1833c12955ca9adf7d13f2",
+        },
+        {
+            # Released 5/12/2016
+            "version": "21.0.0.242",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer21_0r0_242_winax.msi",
+            "sha1": "01261660476cdcacf1872a8a5142018bce6de1dc",
+        },
+        {
+            # Released 6/16/2016
+            "version": "22.0.0.192",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer22_0r0_192_winax.msi",
+            "sha1": "6aba77bca04f7170ac90c3852b837027f840b051",
+        },
+        {
+            # Released 7/12/2016
+            "version": "22.0.0.209",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer22_0r0_209_winax.msi",
+            "sha1": "7db31a028cf14bdcdb4374fd941c08412130e384",
+        },
+        {
+            # Released 9/13/2016
+            "version": "23.0.0.162",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer23_0r0_162_winax.msi",
+            "sha1": "4408e4b6c9ced6490d2b0b81d6a62d00776c8042",
+        },
+        {
+            # Released 10/11/2016
+            "version": "23.0.0.185",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer23_0r0_185_winax.msi",
+            "sha1": "b86c4a79c445481992ac41c47a22323068ca40b1",
+        },
+        {
+            # Released 10/26/2016
+            "version": "23.0.0.205",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer23_0r0_205_winax.msi",
+            "sha1": "c329a24860028263631411bd1c37369022473e9a",
+        },
+        {
+            # Released 11/8/2016
+            "version": "23.0.0.207",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer23_0r0_207_winax.msi",
+            "sha1": "699097fa5bbc4d3a0a9733108678ee642d1cc667",
+        },
+        {
+            # Released 12/13/2016
+            "version": "24.0.0.186",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer24_0r0_186_winax.msi",
+            "sha1": "f9828b0e872f71879664078dbaa23b05fff47494",
+        },
+        {
+            # Released 1/10/2017
+            "version": "24.0.0.194",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer24_0r0_194_winax.msi",
+            "sha1": "2d9648adf6fdc05cbc61b037ec5e434c7a73dfe4",
+        },
+        {
+            # Released 2/14/2017
+            "version": "24.0.0.221",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer24_0r0_221_winax.msi",
+            "sha1": "e8ac1c9c4e12ce7164b1f7374e6ef2868ab51e7f",
+        },
+        {
+            # Released 03/14/2017
+            "version": "25.0.0.127",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer25_0r0_127_winax.msi",
+            "sha1": "78618c96a0e65cc1ace1aedb0ecac04972b3ac7f",
+        },
+        {
+            # Released 04/11/2017
+            "version": "25.0.0.148",
+            "url": "https://cuckoo.sh/vmcloak/flashplayer25_0r0_148_winax.msi",
+            "sha1": "e3907d0e0ac26a2db556ee6fa864243f3cb0a9f0",
         },
         {
             "version": "latest",

--- a/vmcloak/dependencies/flash.py
+++ b/vmcloak/dependencies/flash.py
@@ -125,4 +125,15 @@ class Flash(Dependency):
         else:
             self.a.execute("C:\\%s -install" % self.filename)
 
+        mms = ("SilentAutoUpdateEnable=0\r\n"
+               "AutoUpdateDisable=1\r\n"
+               "ProtectedMode=0\r\n")
+
+        if self.h.arch == "x86":
+            mmsfp = "C:\\Windows\\System32\\Macromed\\Flash\\mms.cfg"
+        else:
+            mmsfp = "C:\\Windows\\SysWow64\\Macromed\\Flash\\mms.cfg"
+
+        self.a.upload(mmsfp, mms)
+
         self.a.remove("C:\\%s" % self.filename)

--- a/vmcloak/dependencies/flash.py
+++ b/vmcloak/dependencies/flash.py
@@ -109,9 +109,20 @@ class Flash(Dependency):
             "url": "https://cuckoo.sh/vmcloak/flashplayer20_0d0_228_winax.msi",
             "sha1": "fa86f107111fc7def35742097bf0aa29c82d7638",
         },
+        {
+            "version": "latest",
+            "urls": [
+                "https://fpdownload.macromedia.com/pub/flashplayer/latest/help/install_flash_player_ax.exe",
+            ],
+        },
     ]
 
     def run(self):
         self.upload_dependency("C:\\%s" % self.filename)
-        self.a.execute("msiexec /i C:\\%s /passive" % self.filename)
+
+        if self.filename.endswith(".msi"):
+            self.a.execute("msiexec /i C:\\%s /passive" % self.filename)
+        else:
+            self.a.execute("C:\\%s -install" % self.filename)
+
         self.a.remove("C:\\%s" % self.filename)

--- a/vmcloak/dependencies/ie11.py
+++ b/vmcloak/dependencies/ie11.py
@@ -36,3 +36,99 @@ class IE11(Dependency):
         self.upload_dependency("C:\\setup.exe")
         self.a.execute("C:\\setup.exe /quiet /norestart /update-no")
         self.a.remove("C:\\setup.exe")
+
+        # disable first use popup:
+        # http://www.geoffchappell.com/notes/windows/ie/firstrun.htm
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v DisableFirstRunCustomize /t REG_DWORD /d 1 /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v RunOnceComplete /t REG_DWORD /d 1 /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v RunOnceHasShown /t REG_DWORD /d 1 /f"
+        )
+
+        # disable auto update:
+        # https://social.technet.microsoft.com/Forums/en-US/c49c96f7-247e-4404-b80f-3df5253dc13f/how-to-uncheck-install-new-versions-automatically-from-internet-explorer-11-from-sccm-2012?forum=ieitprocurrentver
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v EnableAutoUpgrade /t REG_DWORD /d 0 /f"
+        )
+
+        # disable protected mode for all zones for all users
+        # https://superuser.com/questions/1031225/what-is-the-registry-setting-to-enable-protected-mode-in-a-specific-zone
+        for zone in range(0, 5):
+            self.a.execute(
+                "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+                "Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\%s\" "
+                "/v 2500 /t REG_DWORD /d 3 /f" % zone
+            )
+
+        # Disable protected mode
+        # https://www.eightforums.com/tutorials/31977-internet-explorer-enhanced-protected-mode-turn-off.html
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v Isolation /t REG_SZ /d \"PMIL\" /f"
+        )
+
+        # weaken IE11 security
+        # http://www.geoffchappell.com/notes/windows/ie/featurecontrol.htm
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\\"
+            "FeatureControl\\FEATURE_LOCALMACHINE_LOCKDOWN\" "
+            "/v \"iexplore.exe\" /t REG_DWORD /d 0 /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\\"
+            "FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD\" "
+            "/v \"iexplore.exe\" /t REG_DWORD /d 0 /f"
+        )
+
+        # Disable "fix security settings" warning
+        # https://answers.microsoft.com/en-us/ie/forum/ie8-windows_other/when-opening-internet-explorer-constantly-getting/e591c609-1e50-4210-a770-2474beb1430f?auth=1
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\\Security\" "
+            "/v DisableFixSecuritySettings /t REG_DWORD /d 1 /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\\Security\" "
+            "/v DisableSecuritySettingsCheck /t REG_DWORD /d 1 /f"
+        )
+
+        # Disable IE8 IE9+ smartscreen filter:
+        # https://www.sevenforums.com/tutorials/1406-internet-explorer-smartscreen-filter-turn-off.html
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\PhishingFilter\" "
+            "/v EnabledV8 /t REG_DWORD /d 0 /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\PhishingFilter\" "
+            "/v EnabledV9 /t REG_DWORD /d 0 /f"
+        )
+
+        # set default webpage and disable IE default browser check:
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v \"Check_Associations\" /t REG_SZ /d \"no\" /f"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\"
+            "Microsoft\\Internet Explorer\\Main\" "
+            "/v \"Start Page\" /t REG_SZ /d \"about:blank\" /f"
+        )

--- a/vmcloak/dependencies/ie11.py
+++ b/vmcloak/dependencies/ie11.py
@@ -63,6 +63,12 @@ class IE11(Dependency):
             "/v EnableAutoUpgrade /t REG_DWORD /d 0 /f"
         )
 
+        #   0        My Computer
+        #   1        Local Intranet Zone
+        #   2        Trusted sites Zone
+        #   3        Internet Zone
+        #   4        Restricted Sites Zone
+        # https://support.microsoft.com/en-us/help/182569/internet-explorer-security-zones-registry-entries-for-advanced-users
         # disable protected mode for all zones for all users
         # https://superuser.com/questions/1031225/what-is-the-registry-setting-to-enable-protected-mode-in-a-specific-zone
         for zone in range(0, 5):

--- a/vmcloak/dependencies/ie11.py
+++ b/vmcloak/dependencies/ie11.py
@@ -15,13 +15,19 @@ class IE11(Dependency):
         {
             "version": "11",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/IE11-Windows6.1-x64-en-us.exe",
+            "urls": [
+                "https://download.microsoft.com/download/7/1/7/7179A150-F2D2-4502-9D70-4B59EA148EAA/IE11-Windows6.1-x64-en-us.exe",
+                "https://cuckoo.sh/vmcloak/IE11-Windows6.1-x64-en-us.exe",
+            ],
             "sha1": "ddec9ddc256ffa7d97831af148f6cc45130c6857",
         },
         {
             "version": "11",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/IE11-Windows6.1-x86-en-us.exe",
+            "urls": [
+                "https://download.microsoft.com/download/9/2/F/92FC119C-3BCD-476C-B425-038A39625558/IE11-Windows6.1-x86-en-us.exe",
+                "https://cuckoo.sh/vmcloak/IE11-Windows6.1-x86-en-us.exe",
+            ],
             "sha1": "fefdcdde83725e393d59f89bb5855686824d474e",
         },
     ]

--- a/vmcloak/dependencies/java.py
+++ b/vmcloak/dependencies/java.py
@@ -33,19 +33,45 @@ deployment.expiration.check.enabled=false
 
 class Java(Dependency):
     name = "java"
-    default = "7"
+    default = "jdk7"
     recommended = True
     exes = [
         # http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html
         {
-            "version": "7",
+            "version": "jdk7",
             "url": "https://cuckoo.sh/vmcloak/jdk-7-windows-i586.exe",
             "sha1": "2546a78b6138466b3e23e25b5ca59f1c89c22d03",
         },
         {
-            "version": "7u1",
+            "version": "7",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=50974",
+            ],
+            "sha1": "0faa00705651531c831380a6af83b564b995ecb0",
+            "filename": "jre-7-windows-i586.exe",
+        },
+        {
+            "version": "jdk7u1",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u1-windows-i586.exe",
             "sha1": "ed434b8bc132a5bfda031428b26daf7b8331ecb9",
+        },
+        {
+            "arch": "x86",
+            "version": "7u1",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=56868",
+            ],
+            "sha1": "26ec209d66c3b21ef3c7b6c1f3b9fa52466420ed",
+            "filename": "jre-7u1-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u1",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=56869",
+            ],
+            "sha1": "bd40f1dcd72326bb472cd131acb04d707566e706",
+            "filename": "jre-7u1-windows-x64.exe",
         },
         {
             "version": "7u2",
@@ -53,9 +79,27 @@ class Java(Dependency):
             "sha1": "a36ae80b80dd1c9c5c466b3eb2451cd649613cfb",
         },
         {
-            "version": "7u3",
+            "version": "jdk7u3",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u3-windows-i586.exe",
             "sha1": "fe9dc13c0a6424158dc0f13a6246a53973fb5369",
+        },
+        {
+            "arch": "x86",
+            "version": "7u3",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=60508",
+            ],
+            "sha1": "61f48fa0875c85acc8fe1476a1297212f96ea827",
+            "filename": "jre-7u3-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u3",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=60509",
+            ],
+            "sha1": "0d74117467cd905f41fd807f7cdbaa671a150311",
+            "filename": "jre-7u3-windows-x64.exe",
         },
         {
             "version": "7u4",
@@ -63,9 +107,27 @@ class Java(Dependency):
             "sha1": "a2e927632b2106f5efefc906ed9070d8c0bf660f",
         },
         {
-            "version": "7u5",
+            "version": "jdk7u5",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u5-windows-i586.exe",
             "sha1": "88c2fc5e5e61e7f709370c01abb138c65009307b",
+        },
+        {
+            "arch": "x86",
+            "version": "7u5",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=65692",
+            ],
+            "sha1": "504d94c7cc1617b44af8d81de6fd83120b04dfa5",
+            "filename": "jre-7u5-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u5",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=65693",
+            ],
+            "sha1": "ca01de8bf2290c9b891c0bf4aac4c099f66d80e7",
+            "filename": "jre-7u5-windows-x64.exe",
         },
         {
             "version": "7u6",
@@ -73,89 +135,395 @@ class Java(Dependency):
             "sha1": "09f3a1d0fe7fabd4cfdc1c23d1ed16016d064d01",
         },
         {
-            "version": "7u7",
+            "version": "jdk7u7",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u7-windows-i586.exe",
             "sha1": "58e4bdd12225379284542b161e49d8eaea4e00c2",
         },
         {
-            "version": "7u9",
+            "arch": "x86",
+            "version": "7u7",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=68242",
+            ],
+            "sha1": "fad4496cd61a0ef1b42c27aeb405a3739ea0943f",
+            "filename": "jre-7u7-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u7",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=68736",
+            ],
+            "sha1": "9af03460c416931bdee18c2dcebff5db50cb8cb3",
+            "filename": "jre-7u7-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u9",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u9-windows-i586.exe",
             "sha1": "11a256bd791033527580c6ac8700f3a72f7f4bcf",
         },
         {
-            "version": "7u10",
+            "arch": "x86",
+            "version": "7u9",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=69474",
+            ],
+            "sha1": "18c70915192bf5069543b8f95dd44f159ea6deec",
+            "filename": "jre-7u9-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u9",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=69476",
+            ],
+            "sha1": "7ae6d07324439a203af612789110691f757b980e",
+            "filename": "jre-7u9-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u10",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u10-windows-i586.exe",
             "sha1": "f57bfa38a05433d902582fab9d08f530d7c7749b",
         },
         {
-            "version": "7u11",
+            "arch": "x86",
+            "version": "7u10",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=71835",
+            ],
+            "sha1": "d159c752086d6134aacb2e15a10ccaf8ef39bca0",
+            "filename": "jre-7u10-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u10",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=71837",
+            ],
+            "sha1": "1c01773d0fd8e53af5fbf3cd2203ad6cf2545dbc",
+            "filename": "jre-7u10-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u11",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u11-windows-i586.exe",
             "sha1": "a482e48e151cff76dcc1479b9efc367da8fb66a7",
         },
         {
-            "version": "7u13",
+            "arch": "x86",
+            "version": "7u11",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=73141",
+            ],
+            "sha1": "682fb136563f08c20d37b25a28fce0883f893d8b",
+            "filename": "jre-7u11-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u11",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=73143",
+            ],
+            "sha1": "41c3af2cf67c367066863a067ce831cf80586cdb",
+            "filename": "jre-7u11-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u13",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u13-windows-i586.exe",
             "sha1": "bd6848138385510b32897a5b04c94aa4cf2b4fca",
         },
         {
-            "version": "7u15",
+            "arch": "x86",
+            "version": "7u13",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=73857",
+            ],
+            "sha1": "72ad271c6c7e7d1893a9661aad2854a75e87cd5f",
+            "filename": "jre-7u13-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u13",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=73859",
+            ],
+            "sha1": "0acc9b9d6a7f4ebd255c0cc720a6f452797c487f",
+            "filename": "jre-7u13-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u15",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u15-windows-i586.exe",
             "sha1": "f52453c6fd665b89629e639abdb41492eff9a9e3",
         },
         {
-            "version": "7u17",
+            "arch": "x86",
+            "version": "7u15",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=74781",
+            ],
+            "sha1": "5348714e363eb7df9ce5698cfcbb324e525cbd92",
+            "filename": "jre-7u15-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u15",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=74783",
+            ],
+            "sha1": "53345cc82bee2a8ddce8dea26992f371e25f37cd",
+            "filename": "jre-7u15-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u17",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u17-windows-i586.exe",
             "sha1": "1f462dea65c74dd9fdf094d852e438a0e6a036bc",
         },
         {
-            "version": "7u21",
+            "arch": "x86",
+            "version": "7u17",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=75259",
+            ],
+            "sha1": "7b2cd00ec4c57396642afcc463e6d895772925a8",
+            "filename": "jre-7u17-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u17",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=75261",
+            ],
+            "sha1": "eac554818507609480e8a890e232b3a8b0b2f55e",
+            "filename": "jre-7u17-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u21",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u21-windows-i586.exe",
             "sha1": "f677efa8309e99fe3a47ea09295b977af01f2142",
         },
         {
-            "version": "7u25",
+            "arch": "x86",
+            "version": "7u21",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=76860",
+            ],
+            "sha1": "620472dc1e7d015ed9a7700b846565a707946fcb",
+            "filename": "jre-7u21-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u21",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=76862",
+            ],
+            "sha1": "9ec7523c5b8f5621ae21ab2fec12597ea029bb7f",
+            "filename": "jre-7u21-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u25",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u25-windows-i586.exe",
             "sha1": "5eeb8869f9abcb8d575a7f75a6f85550edf680f5",
         },
         {
-            "version": "7u40",
+            "arch": "x86",
+            "version": "7u25",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=78825",
+            ],
+            "sha1": "08ce588fb3668e987a0fa93becf754e9c8027d51",
+            "filename": "jre-7u25-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u25",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=78827",
+            ],
+            "sha1": "ad65e982d8ebf03bb2ddbb418aa26ab499daee41",
+            "filename": "jre-7u25-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u40",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u40-windows-i586.exe",
             "sha1": "b611fb48bb5071b54ef45633cd796a27d5cd0ffd",
         },
         {
-            "version": "7u45",
+            "arch": "x86",
+            "version": "7u40",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=80812",
+            ],
+            "sha1": "c0429dca47c0f22bbcd33492f39117245bab515d",
+            "filename": "jre-7u40-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u40",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=80814",
+            ],
+            "sha1": "85c7db9a1c432a119c90d1d1b203ccaaedae3444",
+            "filename": "jre-7u40-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u45",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u45-windows-i586.exe",
             "sha1": "cfd7e00fa0f6b3eef32832dd7487c6f56e7f55b8",
         },
         {
-            "version": "7u51",
+            "arch": "x86",
+            "version": "7u45",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=81819",
+            ],
+            "sha1": "a2269c804418186c9b944746f26e225b3e77a571",
+            "filename": "jre-7u45-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u45",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=81821",
+            ],
+            "sha1": "155008d2cb8392befb4dcfec8afc5fd2c84173cc",
+            "filename": "jre-7u45-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u51",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u51-windows-i586.exe",
             "sha1": "439435a1b40053761e3a555e97befb4573c303e5",
         },
         {
-            "version": "7u55",
+            "arch": "x86",
+            "version": "7u51",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=83383",
+            ],
+            "sha1": "72aa32f97a0ddd306d436ac3f13fabb841b94a76",
+            "filename": "jre-7u51-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u51",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=83385",
+            ],
+            "sha1": "0d3346f4c249d9443237205cc1c0dde1ef534874",
+            "filename": "jre-7u51-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u55",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u55-windows-i586.exe",
             "sha1": "bb244a96e58724415380877230d2f6b466e9e581",
         },
         {
-            "version": "7u60",
+            "arch": "x86",
+            "version": "7u55",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=86895",
+            ],
+            "sha1": "96b937f49f07068313530db491b92e7e9afb80ba",
+            "filename": "jre-7u55-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u55",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=87443",
+            ],
+            "sha1": "567c3bc32254b2235f0bc30e910323e2dd1e38aa",
+            "filename": "jre-7u55-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u60",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u60-windows-i586.exe",
             "sha1": "8f9185b1fb80dee64e511e222c1a9742eff7837f",
         },
         {
-            "version": "7u65",
+            "arch": "x86",
+            "version": "7u60",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=90223",
+            ],
+            "sha1": "1672aed79505e52b6c39ee706d2f424910ad4493",
+            "filename": "jre-7u60-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u60",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=90225",
+            ],
+            "sha1": "29162a9087b41a0fb2a476ebc78ae5d2ae02495a",
+            "filename": "jre-7u60-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u65",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u65-windows-i586.exe",
             "sha1": "9c52a8185b9931b8ae935adb63c8272cf6d9e9ba",
         },
         {
-            "version": "7u67",
+            "arch": "x86",
+            "version": "7u65",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=90223",
+            ],
+            "sha1": "0eb1db8fd71552ed48099881e2bde8bd41bbe53a",
+            "filename": "jre-7u65-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u65",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=90225",
+            ],
+            "sha1": "8154af812e608bd0c8193c4d5e332a4133ed1aee",
+            "filename": "jre-7u60-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u67",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u67-windows-i586.exe",
             "sha1": "dff04608d4c045cdd66dffe726aed27b22939c9e",
         },
         {
-            "version": "7u71",
+            "arch": "x86",
+            "version": "7u67",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=95123",
+            ],
+            "sha1": "cdcb564088e565b3ed56d9bc9d80448a4e3a9fc6",
+            "filename": "jre-7u67-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u67",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=95125",
+            ],
+            "sha1": "7d9413d367faa0b096ee72c2d5f1983bb7334e9e",
+            "filename": "jre-7u67-windows-x64.exe",
+        },
+        {
+            "version": "jdk7u71",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u71-windows-i586.exe",
             "sha1": "8ca5c5ad43148dfc0e5640db114e317f1bbd6a25",
+        },
+        {
+            "arch": "x86",
+            "version": "7u71",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=97807",
+            ],
+            "sha1": "b04ba06f787b596c57ede7e3c0250546d0635f73",
+            "filename": "jre-7u71-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u71",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=97809",
+            ],
+            "sha1": "714240cf53190bfccb0bb237323a2496300be946",
+            "filename": "jre-7u71-windows-x64.exe",
         },
         {
             "version": "7u72",
@@ -163,9 +531,27 @@ class Java(Dependency):
             "sha1": "57f7dff98bdfbe064af159bbd1d8753cad714f68",
         },
         {
-            "version": "7u75",
+            "version": "jdk7u75",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u75-windows-i586.exe",
             "sha1": "700e56c9b57f5349d4fe9ba28878973059dc68fa",
+        },
+        {
+            "arch": "x86",
+            "version": "7u75",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=101467",
+            ],
+            "sha1": "cd5f2222c6a9db6adfb385eaaeff8f95ea32446f",
+            "filename": "jre-7u75-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u75",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=101469",
+            ],
+            "sha1": "488492de778fc47f67a33c65ea922124279c20d4",
+            "filename": "jre-7u75-windows-x64.exe",
         },
         {
             "version": "7u76",
@@ -173,9 +559,27 @@ class Java(Dependency):
             "sha1": "0469ba6302aa3dc03e39075451aef1c60e5e4114",
         },
         {
-            "version": "7u79",
+            "version": "jdk7u79",
             "url": "https://cuckoo.sh/vmcloak/jdk-7u79-windows-i586.exe",
             "sha1": "319306c148c97f404c00e5562b11f5f4ea5fd6e5",
+        },
+        {
+            "arch": "x86",
+            "version": "7u79",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=106367",
+            ],
+            "sha1": "b062b03a04e0f3ce222282ca1760e4234d3c6f1f",
+            "filename": "jre-7u79-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "7u79",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=106369",
+            ],
+            "sha1": "6e407b926eaf023e4248fdfffa810ded9d4ac7a3",
+            "filename": "jre-7u79-windows-x64.exe",
         },
         {
             "version": "7u80",
@@ -189,9 +593,27 @@ class Java(Dependency):
             "sha1": "09a05b1afad97ffa35a47d571752c3e804c200c7",
         },
         {
-            "version": "8u5",
+            "version": "jdk8u5",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u5-windows-i586.exe",
             "sha1": "81660732a53e08651c633d99b0e6042cbbaf616d",
+        },
+        {
+            "arch": "x86",
+            "version": "8u5",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=86957",
+            ],
+            "sha1": "ca48401f6f71ad360b3c0882393e2c93c35f80de",
+            "filename": "jre-8u5-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u5",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=86958",
+            ],
+            "sha1": "ca656e8a722c068939665ad23760b8b072281594",
+            "filename": "jre-8u5-windows-x64.exe",
         },
         {
             "version": "8u11",
@@ -204,49 +626,211 @@ class Java(Dependency):
             "sha1": "30df3349f710e6b54adccadadc1e1f939ab2f6da",
         },
         {
-            "version": "8u25",
+            "version": "jdk8u25",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u25-windows-i586.exe",
             "sha1": "79b4b68aea5ef6448c39c2ee3103722db6548ff0",
         },
         {
-            "version": "8u31",
+            "arch": "x86",
+            "version": "8u25",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=98426",
+            ],
+            "sha1": "ff3d21c97e9ca71157f12221ccf0788a9775ec92",
+            "filename": "jre-8u25-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u25",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=98428",
+            ],
+            "sha1": "73024362b55d35f77562f203faba892c7540b68d",
+            "filename": "jre-8u25-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u31",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u31-windows-i586.exe",
             "sha1": "5b8a1f8d11ecbcd46ed3389498ef67a4f699133b",
         },
         {
-            "version": "8u40",
+            "arch": "x86",
+            "version": "8u31",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=101406",
+            ],
+            "sha1": "b8ef84ba6a68c35b5d7a5304b4c0304aa53858b8",
+            "filename": "jre-8u31-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u31",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=101408",
+            ],
+            "sha1": "00b5d23743d097d9b8f50bd14602bf4bae525b00",
+            "filename": "jre-8u31-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u40",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u40-windows-i586.exe",
             "sha1": "ff9f4d62dffa0a81abbc0e5e151586301ddf4884",
         },
         {
-            "version": "8u45",
+            "arch": "x86",
+            "version": "8u40",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=103426",
+            ],
+            "sha1": "c583ea81fe3cf6b06e2851f6805ec895226a0053",
+            "filename": "jre-8u40-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u40",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=103428",
+            ],
+            "sha1": "3034ee9474c8829cb9145f3ceadf4e4f8618b9f8",
+            "filename": "jre-8u40-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u45",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u45-windows-i586.exe",
             "sha1": "8e839fe0e30a56784566017f6acdb0fbe213c8bc",
         },
         {
-            "version": "8u51",
+            "arch": "x86",
+            "version": "8u45",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=106246",
+            ],
+            "sha1": "7fc89bd7f82a092d2aa15b753f1fa17e47b879aa",
+            "filename": "jre-8u45-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u45",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=106248",
+            ],
+            "sha1": "4d71c0fccdad64149da2edbd89b8871c83ad5f7e",
+            "filename": "jre-8u45-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u51",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u51-windows-i586.exe",
             "sha1": "0aaee8ff5f62fdcb3685d513be471c49824d7e04",
         },
         {
-            "version": "8u60",
+            "arch": "x86",
+            "version": "8u51",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=107943",
+            ],
+            "sha1": "e0e42aaeedbb77a19809004a576496dcdcf99ed5",
+            "filename": "jre-8u51-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u51",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=107944",
+            ],
+            "sha1": "447fd1f59219282ec5d2f7a179ac12cc072171c3",
+            "filename": "jre-8u51-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u60",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u60-windows-i586.exe",
             "sha1": "47b36bc0fdc44029f82a50346fbb85b8f7803d7f",
         },
         {
-            "version": "8u65",
+            "arch": "x86",
+            "version": "8u60",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=109706",
+            ],
+            "sha1": "bd486f62bc358b1180218480a1cbb0a42483af98",
+            "filename": "jre-8u60-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u60",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=109708",
+            ],
+            "sha1": "87976e29f58276685c63833ae42df7b2b5fe921c",
+            "filename": "jre-8u60-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u65",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u65-windows-i586.exe",
             "sha1": "66bdacc1252f309f157fd0786d2e148dbb394629",
         },
         {
-            "version": "8u66",
+            "arch": "x86",
+            "version": "8u65",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=111687",
+            ],
+            "sha1": "5e0b4ef55faf1de9b4b85d769bfe0899481c5d79",
+            "filename": "jre-8u65-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u65",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=111689",
+            ],
+            "sha1": "85a8021af3299e5bc439a071e8b2cea6a137c6ad",
+            "filename": "jre-8u65-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u66",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u66-windows-i586.exe",
             "sha1": "0013f600723a1a16aa97f7c3fbe1c27fd7674cbe",
         },
         {
-            "version": "8u71",
+            "arch": "x86",
+            "version": "8u66",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=113217",
+            ],
+            "sha1": "b35523fe8891f4f29942482b0b9a205801294595",
+            "filename": "jre-8u66-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u66",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=113219",
+            ],
+            "sha1": "b5a1871e28ab78aa0d48f0d61b3e03e98db50510",
+            "filename": "jre-8u66-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u71",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u71-windows-i586.exe",
             "sha1": "c6726fb46cb40b42b4b545502ee87172b7d290f5",
+        },
+        {
+            "arch": "x86",
+            "version": "8u71",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=114687",
+            ],
+            "sha1": "42db2fbd719a173f6d6d81bbb05f4033628c798c",
+            "filename": "jre-8u71-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u71",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=114689",
+            ],
+            "sha1": "7875f835edf7383b221ca7a4f6b81072727f6eed",
+            "filename": "jre-8u71-windows-x64.exe",
         },
         {
             "version": "8u72",
@@ -254,9 +838,27 @@ class Java(Dependency):
             "sha1": "d1b6e793c21f1bec935f647ec49a12bc54109ace",
         },
         {
-            "version": "8u73",
+            "version": "jdk8u73",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u73-windows-i586.exe",
             "sha1": "f56e21ece567f42fce5a38961bd81288dd2956c0",
+        },
+        {
+            "arch": "x86",
+            "version": "8u73",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=116028",
+            ],
+            "sha1": "77551adf49d25bcbd3f9217190a87df8aef12b8a",
+            "filename": "jre-8u73-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u73",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=116030",
+            ],
+            "sha1": "12c3e70c4348ba89e3817a5b48a41b26b1245550",
+            "filename": "jre-8u73-windows-x64.exe",
         },
         {
             "version": "8u74",
@@ -264,14 +866,50 @@ class Java(Dependency):
             "sha1": "8fa2c7f22b9176d0201d40dc21c29bc7002f5251",
         },
         {
-            "version": "8u77",
+            "version": "jdk8u77",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u77-windows-i586.exe",
             "sha1": "1560add14dde3e4c5bac020116f5bc06d49be567",
         },
         {
-            "version": "8u91",
+            "arch": "x86",
+            "version": "8u77",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=207229",
+            ],
+            "sha1": "c8a7641fb59e5a92118d6875c2598017852a89b1",
+            "filename": "jre-8u77-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u77",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=207231",
+            ],
+            "sha1": "bba6259c407aef6fb746140965d7285911c42ce1",
+            "filename": "jre-8u77-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u91",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u91-windows-i586.exe",
             "sha1": "5374b68f6cca15345fd7d8de0b352cd37804068d",
+        },
+        {
+            "arch": "x86",
+            "version": "8u91",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=207773",
+            ],
+            "sha1": "917463bf8712a0f2ec17704fe7170c735088a915",
+            "filename": "jre-8u91-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u91",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=207775",
+            ],
+            "sha1": "1b7710217149ff0981949c77aa8aa4cbc5597991",
+            "filename": "jre-8u91-windows-x64.exe",
         },
         {
             "version": "8u92",
@@ -279,9 +917,27 @@ class Java(Dependency):
             "sha1": "b89aa89d66ea1783628f62487a137c993af7ca8b",
         },
         {
-            "version": "8u101",
+            "version": "jdk8u101",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u101-windows-i586.exe",
             "sha1": "2d2d56f5774cc2f15d9e54bebc9a868913e606b7",
+        },
+        {
+            "arch": "x86",
+            "version": "8u101",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=211997",
+            ],
+            "sha1": "ae3ad283a4a175a3b5e1e143330ce194b7ebe560",
+            "filename": "jre-8u101-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u101",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=211999",
+            ],
+            "sha1": "cb8404bafad323694d7aa622f02d466073c61c2d",
+            "filename": "jre-8u101-windows-x64.exe",
         },
         {
             "version": "8u102",
@@ -289,16 +945,72 @@ class Java(Dependency):
             "sha1": "3acf0fca1d5bf56f8a2ce577d055bfd0dd1773f9",
         },
         {
-            "version": "8u121",
+            "arch": "x86",
+            "version": "8u111",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=216432",
+            ],
+            "sha1": "11d6a333a6d1b939a4d40082a4acab737071a7b8",
+            "filename": "jre-8u111-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u111",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=216434",
+            ],
+            "sha1": "12e9492f2f2066f5b9187ed00995ede95491c445",
+            "filename": "jre-8u111-windows-x64.exe",
+        },
+        {
+            "version": "jdk8u121",
             "url": "https://cuckoo.sh/vmcloak/jdk-8u121-windows-i586.exe",
             "sha1": "e71fc3eb9f895eba5c2836b05d627884edd0157a",
+        },
+        {
+            "arch": "x86",
+            "version": "8u121",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=218831_e9e7ea248e2c4826b92b3f075a80e441",
+            ],
+            "sha1": "22ae33babe447fb28789bce713a20cbee796a37c",
+            "filename": "jre-8u121-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u121",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=218833_e9e7ea248e2c4826b92b3f075a80e441",
+            ],
+            "sha1": "8b22c68147ba96a8ac6e18360ff2739a1c6ca1db",
+            "filename": "jre-8u121-windows-x64.exe",
+        },
+        {
+            "arch": "x86",
+            "version": "8u131",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=220313_d54c1d3a095b4ff2b6607d096fa80163",
+            ],
+            "sha1": "62762159368ea5fa7681913d2de3633c0d77ad2e",
+            "filename": "jre-8u131-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u131",
+            "urls": [
+                "http://javadl.sun.com/webapps/download/AutoDL?BundleId=220315_d54c1d3a095b4ff2b6607d096fa80163",
+            ],
+            "sha1": "a3a75ebdab5079aac1b3c2f2a4666296214f0417",
+            "filename": "jre-8u131-windows-x64.exe",
         },
     ]
 
     def run(self):
         self.upload_dependency("C:\\java.exe")
 
-        if self.version.startswith("7"):
+        version = self.version.strip("jdk")
+
+        if version.startswith("7"):
             self.a.execute("C:\\java.exe /s WEB_JAVA=1 WEB_JAVA_SECURITY_LEVEL=M SPONSORS=0", async=True)
             self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.config", deploymentconfig)
             self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.properties", deploymentproperties)
@@ -312,7 +1024,7 @@ class Java(Dependency):
 
         self.a.remove("C:\\java.exe")
 
-        if not self.version.startswith("7"):
+        if not version.startswith("7"):
             self.a.remove("C:\\config.cfg")
 
         if self.i.osversion == "winxp" or self.i.osversion == "win7x86":

--- a/vmcloak/dependencies/java.py
+++ b/vmcloak/dependencies/java.py
@@ -13,6 +13,24 @@ WEB_JAVA_SECURITY_LEVEL=H
 WEB_ANALYTICS=Disable
 """
 
+java7deploymentconfig = """
+deployment.system.config=file:///C:/Windows/Sun/Java/Deployment/deployment.properties
+deployment.system.config.mandatory=false
+"""
+
+java7deploymentproperties = """
+deployment.security.level=medium
+deployment.security.jsse.hostmismatch.warning=false
+deployment.security.mixcode=disable
+deployment.security.blacklist.check=false
+deployment.security.sandbox.awtwarningwindow=false
+deployment.javaws.shortcut=always
+deployment.javaws.associations=always
+deployment.webjava.enabled=true
+deployment.insecure.jres=never
+deployment.expiration.check.enabled=false
+"""
+
 class Java(Dependency):
     name = "java"
     default = "7"
@@ -282,6 +300,8 @@ class Java(Dependency):
 
         if self.version.startswith("7"):
             self.a.execute("C:\\java.exe /s WEB_JAVA=1 WEB_JAVA_SECURITY_LEVEL=M SPONSORS=0", async=True)
+            self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.config", deploymentconfig)
+            self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.properties", deploymentproperties)
         else:
             self.a.upload("C:\\config.cfg", config)
             self.a.execute("C:\\java.exe INSTALLCFG=C:\\config.cfg", async=True)

--- a/vmcloak/dependencies/java.py
+++ b/vmcloak/dependencies/java.py
@@ -47,6 +47,7 @@ class Java(Dependency):
     recommended = True
     exes = [
         # http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html
+        # https://www.java.com/pt_BR/download/manual.jsp
         {
             "version": "jdk7",
             "url": "https://cuckoo.sh/vmcloak/jdk-7-windows-i586.exe",
@@ -1012,6 +1013,60 @@ class Java(Dependency):
             ],
             "sha1": "a3a75ebdab5079aac1b3c2f2a4666296214f0417",
             "filename": "jre-8u131-windows-x64.exe",
+        },
+        {
+            "arch": "x86",
+            "version": "8u141",
+            "urls": [
+                "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=224927_336fa29ff2bb4ef291e347e091f7f4a7",
+            ],
+            "sha1": "74445e1c2c932f87ad90a55fb5da182f57dd637d",
+            "filename": "jre-8u141-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u141",
+            "urls": [
+                "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=224929_336fa29ff2bb4ef291e347e091f7f4a7",
+            ],
+            "sha1": "77cfba433ca2057e6aef6ac1f82f3a3679bf8533",
+            "filename": "jre-8u141-windows-x64.exe",
+        },
+        {
+            "arch": "x86",
+            "version": "8u144",
+            "urls": [
+                "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=225353_090f390dda5b47b9b721c7dfaa008135",
+            ],
+            "sha1": "49901a5961c2cdd9a46930d4008a8f8d0b1aad27",
+            "filename": "jre-8u144-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u144",
+            "urls": [
+                "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=225355_090f390dda5b47b9b721c7dfaa008135",
+            ],
+            "sha1": "f1c74179507212cd853a87fa3b6a9ea764dea4ed",
+            "filename": "jre-8u144-windows-x64.exe",
+        },
+        {
+            "arch": "x86",
+            "version": "8u151",
+            "urls": [
+                "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=227550_e758a0de34e24606bca991d704f6dcbf",
+            ],
+            "sha1": "94f6903ef5514405131298fc351af9467adf945d",
+            "filename": "jre-8u151-windows-i586.exe",
+        },
+        {
+            "arch": "amd64",
+            "version": "8u151",
+            "urls": [
+                "http://javadl.oracle.com/webapps/download/AutoDL?BundleId=227552_e758a0de34e24606bca991d704f6dcbf",
+            ],
+            "sha1": "57747ce996b5b2f1786601b04a0b0355fc82493a",
+            "filename": "jre-8u151-windows-x64.exe",
         },
     ]
 

--- a/vmcloak/dependencies/java.py
+++ b/vmcloak/dependencies/java.py
@@ -15,20 +15,30 @@ WEB_ANALYTICS=Disable
 
 java7deploymentconfig = """
 deployment.system.config=file:///C:/Windows/Sun/Java/Deployment/deployment.properties
-deployment.system.config.mandatory=false
+deployment.system.config.mandatory=true
 """
 
 java7deploymentproperties = """
-deployment.security.level=medium
+deployment.security.level=MEDIUM
+deployment.security.level.locked
 deployment.security.jsse.hostmismatch.warning=false
-deployment.security.mixcode=disable
+deployment.security.jsse.hostmismatch.warning.locked
+deployment.security.mixcode=DISABLE
+deployment.security.mixcode.locked
 deployment.security.blacklist.check=false
+deployment.security.blacklist.check.locked
 deployment.security.sandbox.awtwarningwindow=false
-deployment.javaws.shortcut=always
-deployment.javaws.associations=always
+deployment.security.sandbox.awtwarningwindow.locked
+deployment.security.revocation.check=NO_CHECK
+deployment.security.revocation.check.locked
+deployment.javaws.shortcut=ALWAYS
+deployment.javaws.shortcut.locked
 deployment.webjava.enabled=true
-deployment.insecure.jres=never
+deployment.webjava.enabled.locked
+deployment.insecure.jres=NEVER
+deployment.insecure.jres.locked
 deployment.expiration.check.enabled=false
+deployment.expiration.check.enabled.locked
 """
 
 class Java(Dependency):
@@ -1011,9 +1021,9 @@ class Java(Dependency):
         version = self.version.strip("jdk")
 
         if version.startswith("7"):
-            self.a.execute("C:\\java.exe /s WEB_JAVA=1 WEB_JAVA_SECURITY_LEVEL=M SPONSORS=0", async=True)
-            self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.config", deploymentconfig)
-            self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.properties", deploymentproperties)
+            self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.config", java7deploymentconfig)
+            self.a.upload("C:\\Windows\\Sun\\Java\\Deployment\\deployment.properties", java7deploymentproperties)
+            self.a.execute("C:\\java.exe /s", async=True)
         else:
             self.a.upload("C:\\config.cfg", config)
             self.a.execute("C:\\java.exe INSTALLCFG=C:\\config.cfg", async=True)

--- a/vmcloak/dependencies/kb.py
+++ b/vmcloak/dependencies/kb.py
@@ -12,109 +12,163 @@ class KB(Dependency):
         {
             "version": "2729094",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2729094-v2-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/6/C/A/6CA15546-A46C-4333-B405-AB18785ABB66/Windows6.1-KB2729094-v2-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2729094-v2-x64.msu",
+            ],
             "sha1": "e1a3ecc5030a51711f558f90dd1db52e24ce074b",
         },
         {
             "version": "2729094",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2729094-v2-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/B/6/B/B6BF1D9B-2568-406B-88E8-E4A218DEA90A/Windows6.1-KB2729094-v2-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2729094-v2-x86.msu",
+            ],
             "sha1": "565e7f2a6562ace748c5b6165aa342a11c96aa98",
         },
         {
             "version": "2731771",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2731771-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/9/F/E/9FE868F6-A0E1-4F46-96E5-87D7B6573356/Windows6.1-KB2731771-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2731771-x64.msu",
+            ],
             "sha1": "98dba6673cedbc2860c76b9686e895664d463347",
         },
         {
             "version": "2731771",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2731771-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/A/0/B/A0BA0A59-1F11-4736-91C0-DFCB06224D99/Windows6.1-KB2731771-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2731771-x86.msu",
+            ],
             "sha1": "86675d2fd327b328793dc179727ce0ce5107a72e",
         },
         {
             "version": "2533623",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2533623-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/F/1/0/F106E158-89A1-41E3-A9B5-32FEB2A99A0B/Windows6.1-KB2533623-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2533623-x64.msu",
+            ],
             "sha1": "8a59ea3c7378895791e6cdca38cc2ad9e83bebff",
         },
         {
             "version": "2533623",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2533623-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/2/D/7/2D78D0DD-2802-41F5-88D6-DC1D559F206D/Windows6.1-KB2533623-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2533623-x86.msu",
+            ],
             "sha1": "25becc0815f3e47b0ba2ae84480e75438c119859",
         },
         {
             "version": "2670838",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2670838-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/1/4/9/14936FE9-4D16-4019-A093-5E00182609EB/Windows6.1-KB2670838-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2670838-x64.msu",
+            ],
             "sha1": "9f667ff60e80b64cbed2774681302baeaf0fc6a6",
         },
         {
             "version": "2670838",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2670838-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/1/4/9/14936FE9-4D16-4019-A093-5E00182609EB/Windows6.1-KB2670838-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2670838-x86.msu",
+            ],
             "sha1": "984b8d122a688d917f81c04155225b3ef31f012e",
         },
         {
             "version": "2786081",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2786081-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/1/8/F/18F9AE2C-4A10-417A-8408-C205420C22C3/Windows6.1-KB2786081-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2786081-x64.msu",
+            ],
             "sha1": "dc63b04c58d952d533c40b185a8b555b50d47905",
         },
         {
             "version": "2786081",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2786081-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/4/8/1/481C640E-D3EE-4ADC-AA48-6D0ED2869D37/Windows6.1-KB2786081-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2786081-x86.msu",
+            ],
             "sha1": "70122aca48659bfb8a06bed08cb7047c0c45c5f4",
         },
         {
             "version": "2639308",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2639308-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/9/1/C/91CC3B0D-F58B-4B36-941D-D810A8FF6805/Windows6.1-KB2639308-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2639308-x64.msu",
+            ],
             "sha1": "67eedaf061e02d503028d970515d88d8fe95579d",
         },
         {
             "version": "2639308",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2639308-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/3/1/D/31DB4F4F-207D-416E-9A07-FBD9E431F9FB/Windows6.1-KB2639308-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2639308-x86.msu",
+            ],
             "sha1": "96e09ef9caf3907a32315839086b9f576bb46459",
         },
         {
             "version": "2834140",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2834140-v2-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/5/A/5/5A548BFE-ADC5-414B-B6BD-E1EC27A8DD80/Windows6.1-KB2834140-v2-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2834140-v2-x64.msu",
+            ],
             "sha1": "3db9d9b3dc20515bf4b164821b721402e34ad9d6",
         },
         {
             "version": "2834140",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2834140-v2-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/F/1/4/F1424AD7-F754-4B6E-B0DA-151C7CBAE859/Windows6.1-KB2834140-v2-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2834140-v2-x86.msu",
+            ],
             "sha1": "b57c05e9da2c66e1bb27868c92db177a1d62b2fb",
         },
         {
             "version": "2882822",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2882822-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/6/1/4/6141BFD5-40FD-4148-A3C9-E355338A9AC8/Windows6.1-KB2882822-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2882822-x64.msu",
+            ],
             "sha1": "ec92821f6ee62ac9d2f74e847f87be0bf9cfcb31",
         },
         {
             "version": "2882822",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2882822-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/7/C/E/7CE5D2A0-3A08-427E-9AA9-8A79E47B87B9/Windows6.1-KB2882822-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2882822-x86.msu",
+            ],
             "sha1": "7fab5b9ca9b5c2395b505d1234ee889941bfb151",
         },
         {
             "version": "2888049",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2888049-x64.msu",
+            "urls": [
+                "https://download.microsoft.com/download/4/1/3/41321D2E-2D08-4699-A635-D9828AADB177/Windows6.1-KB2888049-x64.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2888049-x64.msu",
+            ],
             "sha1": "fae6327b151ae04b56fac431e682145c14474c69",
         },
         {
             "version": "2888049",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2888049-x86.msu",
+            "urls": [
+                "https://download.microsoft.com/download/3/9/D/39D85CA8-7BF3-47C1-9031-FD6E51D8BBEB/Windows6.1-KB2888049-x86.msu",
+                "https://cuckoo.sh/vmcloak/Windows6.1-KB2888049-x86.msu",
+            ],
             "sha1": "65b4c7a5773fab177d20c8e49d773492e55e8d76",
         },
     ]

--- a/vmcloak/dependencies/office.py
+++ b/vmcloak/dependencies/office.py
@@ -17,8 +17,17 @@ config = """
 </Configuration>
 """
 
+officever = {
+    "2016": "16.0",
+    "2013": "15.0",
+    "2010": "14.0",
+    "2007": "12.0",
+    "2003": "11.0",
+}
+
 class Office(Dependency):
     name = "office"
+    default = "2010"
 
     def init(self):
         self.isopath = None
@@ -60,6 +69,213 @@ class Office(Dependency):
         self.wait_process_exit("setup.exe")
 
         self.a.remove("C:\\config.xml")
+
+        # disable first use popup
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\General\" "
+            "/v ShownFirstRunOptin /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+
+        # dont report office binary files (pub/doc/xls/etc) to MS if validation failed
+        # https://blogs.technet.microsoft.com/office2010/2009/12/16/office-2010-file-validation/
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Security\\FileValidation\" "
+            "/v DisableReporting /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+
+        # Disable all privacy settings in all Office products
+        # https://social.technet.microsoft.com/Forums/office/en-US/0db3e246-04b6-4948-a98c-4459fb65b1f9/privacy-options-in-access-2010?forum=officeitproprevious
+        # https://msdn.microsoft.com/en-us/library/office/aa205294(v=office.11).aspx
+        # https://www.stigviewer.com/stig/microsoft_office_system_2007/2014-01-07/finding/V-17740
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Internet\" "
+            "/v UseOnlineContent /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Internet\" "
+            "/v UseOnlineAppDetect /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Internet\" "
+            "/v IDN_AlertOff /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Research\\Options\" "
+            "/v NoDiscovery /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Research\\Options\" "
+            "/v DiscoveryNeedOptIn /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+        # dont use online dictionaries
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\\Research\\Translation\" "
+            "/v UseOnline /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Common\" "
+            "/v UpdateReliabilityData /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # disable activeX warnings, disable AX safe mode
+        # https://www.greyhathacker.net/?p=948
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\Common\\Security\" "
+            "/v DisableAllActiveX /t REG_DWORD /d 0 /f"
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\Common\\Security\" "
+            "/v UFIControls /t REG_DWORD /d 1 /f"
+        )
+
+        # disable Protected View for all office products files
+        for product in ["Access", "Excel", "Outlook", "PowerPoint", "Publisher", "Word"]:
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\ProtectedView\" "
+                "/v DisableAttachmentsInPV /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\ProtectedView\" "
+                "/v DisableInternetFilesInPV /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\ProtectedView\" "
+                "/v DisableUnsafeLocationsInPV /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+
+        for product in ["Excel", "Powerpoint", "Word"]:
+            # disable DEP and macro warnings
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\" "
+                "/v EnableDEP /t REG_DWORD /d 0 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\" "
+                "/v VBAWarnings /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\" "
+                "/v AccessVBOM /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+
+            # Dont show warnings for files from the network
+            self.a.execute(
+                "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+                "Microsoft\\Office\\{}\\{}\\Security\\Trusted Locations\" "
+                "/v AllowNetworkLocations /t REG_DWORD /d 1 /f".format(officever[self.version], product)
+            )
+
+        # Dont block older Word documents
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v OpenInProtectedView /t REG_DWORD /d 2 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v Word2Files /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v Word60Files /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v Word95Files /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # Dont block older Excel documents
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Excel\\Security\\FileBlock\" "
+            "/v OpenInProtectedView /t REG_DWORD /d 2 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL2Macros /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL2Worksheets /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL3Macros /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL3Worksheets /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL4Macros /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL4Workbooks /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Word\\Security\\FileBlock\" "
+            "/v XL4Worksheets /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # Allow data connections without warnings in Excel
+        # https://www.experts-exchange.com/questions/28247804/Enable-Data-Connections-for-all-users.html
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Excel\\Security\" "
+            "/v DataConnectionWarnings /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # auto update workbook links
+        # https://support.microsoft.com/en-us/help/826921/how-to-control-the-startup-message-about-updating-linked-workbooks-in-excel
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Excel\\Security\" "
+            "/v WorkbookLinkWarnings /t REG_DWORD /d 0 /f".format(officever[self.version])
+        )
+
+        # Enable macros in Outlook
+        self.a.execute(
+            "REG ADD \"HKEY_CURRENT_USER\\Software\\"
+            "Microsoft\\Office\\{}\\Outlook\\Security\" "
+            "/v Level /t REG_DWORD /d 1 /f".format(officever[self.version])
+        )
+
+        # disable AV Notification in outlook
+        # https://www.slipstick.com/developer/change-programmatic-access-options/
+        self.a.execute(
+            "REG ADD \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Wow6432Node\\Microsoft\\Office\\{}\\Outlook\\Security\" "
+            "/v ObjectModelGuard /t REG_DWORD /d 2 /f".format(officever[self.version])
+        )
 
         if self.i.vm == "virtualbox":
             self.m.detach_iso()

--- a/vmcloak/dependencies/office.py
+++ b/vmcloak/dependencies/office.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 config = """
 <Configuration Product="ProPlus">
-    <Display Level="none" CompletionNotice="no" SuppressModal="yes" AcceptEula="yes" />
+    <Display Level="basic" CompletionNotice="no" SuppressModal="yes" AcceptEula="yes" />
     <PIDKEY Value="%(serial_key)s" />
     <Setting Id="AUTO_ACTIVATE" Value="%(activate)s" />
 </Configuration>

--- a/vmcloak/dependencies/pillow.py
+++ b/vmcloak/dependencies/pillow.py
@@ -4,12 +4,16 @@
 
 from vmcloak.abstract import Dependency
 
+
 class Pillow(Dependency):
     name = "pillow"
     recommended = True
     exes = [
         {
-            "url": "https://cuckoo.sh/vmcloak/Pillow-2.9.0.win32-py2.7.exe",
+            "urls": [
+                "https://pypi.python.org/packages/2.7/P/Pillow/Pillow-2.9.0.win32-py2.7.exe",
+                "https://cuckoo.sh/vmcloak/Pillow-2.9.0.win32-py2.7.exe",
+            ],
             "sha1": "1138f6db53b54943cbe7cf237c4df7e9255ca034",
         },
     ]

--- a/vmcloak/dependencies/pillow.py
+++ b/vmcloak/dependencies/pillow.py
@@ -8,13 +8,41 @@ from vmcloak.abstract import Dependency
 class Pillow(Dependency):
     name = "pillow"
     recommended = True
+    default = "2.9.0"
     exes = [
         {
+            "arch": "amd64",
+            "version": "2.9.0",
+            "urls": [
+                "https://pypi.python.org/packages/2.7/P/Pillow/Pillow-2.9.0.win-amd64-py2.7.exe",
+            ],
+            "sha1": "3ab2d0f594da58568930bbdedc76ba1e77f8fd48",
+        },
+        {
+            "arch": "x86",
+            "version": "2.9.0",
             "urls": [
                 "https://pypi.python.org/packages/2.7/P/Pillow/Pillow-2.9.0.win32-py2.7.exe",
                 "https://cuckoo.sh/vmcloak/Pillow-2.9.0.win32-py2.7.exe",
             ],
             "sha1": "1138f6db53b54943cbe7cf237c4df7e9255ca034",
+        },
+        {
+            "arch": "amd64",
+            "version": "3.4.2",
+            "urls": [
+                "https://pypi.python.org/packages/20/fd/feb18c21ce98ef377e4b7417707bf4bc15fc29f0972e612e294e6e11ae1a/Pillow-3.4.2.win-amd64-py2.7.exe",
+
+            ],
+            "sha1": "879cdfbe9206c9b4059d0a3c7f339a02a20d0ee5",
+        },
+        {
+            "arch": "x86",
+            "version": "3.4.2",
+            "urls": [
+                "https://pypi.python.org/packages/59/59/ece120265d3918f75b43dda870566e58d675c3e865bf63f520e7f01425e5/Pillow-3.4.2.win32-py2.7.exe",
+            ],
+            "sha1": "46778e4c41cb721b035fb72b82e17bcaba94c077",
         },
     ]
 

--- a/vmcloak/dependencies/pillow.py
+++ b/vmcloak/dependencies/pillow.py
@@ -11,15 +11,6 @@ class Pillow(Dependency):
     default = "2.9.0"
     exes = [
         {
-            "arch": "amd64",
-            "version": "2.9.0",
-            "urls": [
-                "https://pypi.python.org/packages/2.7/P/Pillow/Pillow-2.9.0.win-amd64-py2.7.exe",
-            ],
-            "sha1": "3ab2d0f594da58568930bbdedc76ba1e77f8fd48",
-        },
-        {
-            "arch": "x86",
             "version": "2.9.0",
             "urls": [
                 "https://pypi.python.org/packages/2.7/P/Pillow/Pillow-2.9.0.win32-py2.7.exe",
@@ -28,16 +19,6 @@ class Pillow(Dependency):
             "sha1": "1138f6db53b54943cbe7cf237c4df7e9255ca034",
         },
         {
-            "arch": "amd64",
-            "version": "3.4.2",
-            "urls": [
-                "https://pypi.python.org/packages/20/fd/feb18c21ce98ef377e4b7417707bf4bc15fc29f0972e612e294e6e11ae1a/Pillow-3.4.2.win-amd64-py2.7.exe",
-
-            ],
-            "sha1": "879cdfbe9206c9b4059d0a3c7f339a02a20d0ee5",
-        },
-        {
-            "arch": "x86",
             "version": "3.4.2",
             "urls": [
                 "https://pypi.python.org/packages/59/59/ece120265d3918f75b43dda870566e58d675c3e865bf63f520e7f01425e5/Pillow-3.4.2.win32-py2.7.exe",

--- a/vmcloak/dependencies/python.py
+++ b/vmcloak/dependencies/python.py
@@ -10,18 +10,6 @@ class Python(Dependency):
     default = "2.7.6"
     exes = [
         {
-            "arch": "amd64",
-            "version": "2.7.6",
-            "urls": [
-                "https://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi",
-            ],
-            "sha1": "405290650b85042f389a8fbf06549c35458afd05",
-            "filename": "python-2.7.6.amd64.msi",
-            "window_name": "Python 2.7.6 (64-bit) Setup",
-            "install_path": "C:\\Python27",
-        },
-        {
-            "arch": "x86",
             "version": "2.7.6",
             "urls": [
                 "https://www.python.org/ftp/python/2.7.6/python-2.7.6.msi",
@@ -33,18 +21,6 @@ class Python(Dependency):
             "install_path": "C:\\Python27",
         },
         {
-            "arch": "amd64",
-            "version": "2.7.13",
-            "urls": [
-                "https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64.msi",
-            ],
-            "sha1": "d9113142bae8829365c595735e1ad1f9f5e2894c",
-            "filename": "python-2.7.13.amd64.msi",
-            "window_name": "Python 2.7.13 (64-bit) Setup",
-            "install_path": "C:\\Python27",
-        },
-        {
-            "arch": "x86",
             "version": "2.7.13",
             "urls": [
                 "https://www.python.org/ftp/python/2.7.13/python-2.7.13.msi",

--- a/vmcloak/dependencies/python.py
+++ b/vmcloak/dependencies/python.py
@@ -16,6 +16,9 @@ class Python(Dependency):
                 "https://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi",
             ],
             "sha1": "405290650b85042f389a8fbf06549c35458afd05",
+            "filename": "python-2.7.6.amd64.msi",
+            "window_name": "Python 2.7.6 (64-bit) Setup",
+            "install_path": "C:\\Python27",
         },
         {
             "arch": "x86",
@@ -25,6 +28,9 @@ class Python(Dependency):
                 "https://cuckoo.sh/vmcloak/python-2.7.6.msi",
             ],
             "sha1": "c5d71f339f7edd70ecd54b50e97356191347d355",
+            "filename": "python-2.7.6.msi",
+            "window_name": "Python 2.7.6 Setup",
+            "install_path": "C:\\Python27",
         },
         {
             "arch": "amd64",
@@ -33,6 +39,9 @@ class Python(Dependency):
                 "https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64.msi",
             ],
             "sha1": "d9113142bae8829365c595735e1ad1f9f5e2894c",
+            "filename": "python-2.7.13.amd64.msi",
+            "window_name": "Python 2.7.13 (64-bit) Setup",
+            "install_path": "C:\\Python27",
         },
         {
             "arch": "x86",
@@ -41,6 +50,9 @@ class Python(Dependency):
                 "https://www.python.org/ftp/python/2.7.13/python-2.7.13.msi",
             ],
             "sha1": "7e3b54236dbdbea8fe2458db501176578a4d59c0",
+            "filename": "python-2.7.13.msi",
+            "window_name": "Python 2.7.13 Setup",
+            "install_path": "C:\\Python27",
         },
     ]
 

--- a/vmcloak/dependencies/python27.py
+++ b/vmcloak/dependencies/python27.py
@@ -4,11 +4,15 @@
 
 from vmcloak.abstract import Dependency
 
+
 class Python27(Dependency):
     name = "python27"
     exes = [
         {
-            "url": "https://cuckoo.sh/vmcloak/python-2.7.6.msi",
+            "urls": [
+                "https://www.python.org/ftp/python/2.7.6/python-2.7.6.msi",
+                "https://cuckoo.sh/vmcloak/python-2.7.6.msi",
+            ],
             "sha1": "c5d71f339f7edd70ecd54b50e97356191347d355",
         },
     ]

--- a/vmcloak/dependencies/python27.py
+++ b/vmcloak/dependencies/python27.py
@@ -5,15 +5,42 @@
 from vmcloak.abstract import Dependency
 
 
-class Python27(Dependency):
-    name = "python27"
+class Python(Dependency):
+    name = "python"
+    default = "2.7.6"
     exes = [
         {
+            "arch": "amd64",
+            "version": "2.7.6",
+            "urls": [
+                "https://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi",
+            ],
+            "sha1": "405290650b85042f389a8fbf06549c35458afd05",
+        },
+        {
+            "arch": "x86",
+            "version": "2.7.6",
             "urls": [
                 "https://www.python.org/ftp/python/2.7.6/python-2.7.6.msi",
                 "https://cuckoo.sh/vmcloak/python-2.7.6.msi",
             ],
             "sha1": "c5d71f339f7edd70ecd54b50e97356191347d355",
+        },
+        {
+            "arch": "amd64",
+            "version": "2.7.13",
+            "urls": [
+                "https://www.python.org/ftp/python/2.7.13/python-2.7.13.amd64.msi",
+            ],
+            "sha1": "d9113142bae8829365c595735e1ad1f9f5e2894c",
+        },
+        {
+            "arch": "x86",
+            "version": "2.7.13",
+            "urls": [
+                "https://www.python.org/ftp/python/2.7.13/python-2.7.13.msi",
+            ],
+            "sha1": "7e3b54236dbdbea8fe2458db501176578a4d59c0",
         },
     ]
 
@@ -22,3 +49,8 @@ class Python27(Dependency):
         setup by default when installing a new Virtual Machine. In the end,
         Python is required for running both the Agent as well as Cuckoo's
         Analyzer anyway."""
+
+class Python27(Python, Dependency):
+    """Backwards compatibility."""
+    name = "python27"
+    recommended = False

--- a/vmcloak/dependencies/silverlight.py
+++ b/vmcloak/dependencies/silverlight.py
@@ -6,10 +6,87 @@ from vmcloak.abstract import Dependency
 
 class Silverlight(Dependency):
     name = "silverlight"
+    default = "5.0.61118.0"
     exes = [
         {
-            "url": "https://cuckoo.sh/vmcloak-files/Silverlight_Developer_x86.exe",
-            "sha1": "f87518a85e90050cbe4b4b76308f105c7b37acdc",
+            "arch": "x86",
+            "version": "5.0.61118.0"
+            "urls": [
+                "https://download.microsoft.com/download/5/5/7/55748E53-D673-4225-8072-4C7A377BB513/runtime/Silverlight.exe"
+            ],
+            "sha1": "f0c3c1bce3802addca966783a33db1b668261fb5",
+        },
+        {
+            "arch": "amd64",
+            "version": "5.0.61118.0"
+            "urls": [
+                "https://download.microsoft.com/download/5/5/7/55748E53-D673-4225-8072-4C7A377BB513/runtime/Silverlight_x64.exe"
+            ],
+            "sha1": "c98499e2a2f9ac0f8b70d301e3dee4d4cc4a5f86",
+        },
+        {
+            "arch": "x86",
+            "version": "5.1.40620.0"
+            "urls": [
+                "https://download.microsoft.com/download/5/A/4/5A4F7D41-D714-42B4-9F5F-A2B0B985CBAC/40620.00/Silverlight.exe",
+            ],
+            "sha1": "45f07952e2e6cf8bd972a733aacb213871d086f1",
+        },
+        {
+            "arch": "amd64",
+            "version": "5.1.40620.0"
+            "urls": [
+                "https://download.microsoft.com/download/5/A/4/5A4F7D41-D714-42B4-9F5F-A2B0B985CBAC/40620.00/Silverlight_x64.exe",
+            ],
+            "sha1": "56ade2a82b7083383c9e4453af1da0301b48ac53",
+        },
+        {
+            "arch": "x86",
+            "version": "5.1.50709.0"
+            "urls": [
+                "https://download.microsoft.com/download/7/7/6/7765A6A5-4B02-41DE-B7AF-067C92C581BD/50709.00/Silverlight.exe",
+            ],
+            "sha1": "6e7c5e763ec6dba646adec4a0bcbd88059750658",
+        },
+        {
+            "arch": "amd64",
+            "version": "5.1.50709.0"
+            "urls": [
+                "https://download.microsoft.com/download/7/7/6/7765A6A5-4B02-41DE-B7AF-067C92C581BD/50709.00/Silverlight_x64.exe",
+            ],
+            "sha1": "0222ec109d882a612d65c8ef8daa04af2f72f8fa",
+        },
+        {
+            "arch": "x86",
+            "version": "5.1.50905.0"
+            "urls": [
+                "https://download.microsoft.com/download/8/6/A/86AC5F63-A0C9-4868-8CC5-C653B189E4B6/50905.00/Silverlight.exe",
+            ],
+            "sha1": "97b56d4e390241ae1baabe65d41e4080270bcb1b",
+        },
+        {
+            "arch": "amd64",
+            "version": "5.1.50905.0"
+            "urls": [
+                "https://download.microsoft.com/download/8/6/A/86AC5F63-A0C9-4868-8CC5-C653B189E4B6/50905.00/Silverlight_x64.exe",
+            ],
+            "sha1": "16712886955bab475549184015d425e3091a6357",
+        },
+        {
+            "arch": "x86",
+            "version": "5.1.50906.0"
+            "urls": [
+                "https://download.microsoft.com/download/3/F/5/3F5B3DEC-A698-4B6A-8BB9-A1A554EA103C/50906.00/Silverlight.exe",
+            ],
+            "sha1": "7a811b061f742479d2e25ce5ac1a9908f5745bf1",
+        },
+        {
+            "arch": "amd64",
+            "version": "5.1.50906.0"
+            "urls": [
+                "https://download.microsoft.com/download/3/F/5/3F5B3DEC-A698-4B6A-8BB9-A1A554EA103C/50906.00/Silverlight_x64.exe",
+            ],
+            "sha1": "d10a077bf0043a846f2f2a75962c2e068a060f10",
         },
     ]
 

--- a/vmcloak/dependencies/silverlight.py
+++ b/vmcloak/dependencies/silverlight.py
@@ -10,7 +10,7 @@ class Silverlight(Dependency):
     exes = [
         {
             "arch": "x86",
-            "version": "5.0.61118.0"
+            "version": "5.0.61118.0",
             "urls": [
                 "https://download.microsoft.com/download/5/5/7/55748E53-D673-4225-8072-4C7A377BB513/runtime/Silverlight.exe"
             ],
@@ -18,7 +18,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "amd64",
-            "version": "5.0.61118.0"
+            "version": "5.0.61118.0",
             "urls": [
                 "https://download.microsoft.com/download/5/5/7/55748E53-D673-4225-8072-4C7A377BB513/runtime/Silverlight_x64.exe"
             ],
@@ -26,7 +26,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "x86",
-            "version": "5.1.40620.0"
+            "version": "5.1.40620.0",
             "urls": [
                 "https://download.microsoft.com/download/5/A/4/5A4F7D41-D714-42B4-9F5F-A2B0B985CBAC/40620.00/Silverlight.exe",
             ],
@@ -34,7 +34,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "amd64",
-            "version": "5.1.40620.0"
+            "version": "5.1.40620.0",
             "urls": [
                 "https://download.microsoft.com/download/5/A/4/5A4F7D41-D714-42B4-9F5F-A2B0B985CBAC/40620.00/Silverlight_x64.exe",
             ],
@@ -42,7 +42,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "x86",
-            "version": "5.1.50709.0"
+            "version": "5.1.50709.0",
             "urls": [
                 "https://download.microsoft.com/download/7/7/6/7765A6A5-4B02-41DE-B7AF-067C92C581BD/50709.00/Silverlight.exe",
             ],
@@ -50,7 +50,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "amd64",
-            "version": "5.1.50709.0"
+            "version": "5.1.50709.0",
             "urls": [
                 "https://download.microsoft.com/download/7/7/6/7765A6A5-4B02-41DE-B7AF-067C92C581BD/50709.00/Silverlight_x64.exe",
             ],
@@ -58,7 +58,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "x86",
-            "version": "5.1.50905.0"
+            "version": "5.1.50905.0",
             "urls": [
                 "https://download.microsoft.com/download/8/6/A/86AC5F63-A0C9-4868-8CC5-C653B189E4B6/50905.00/Silverlight.exe",
             ],
@@ -66,7 +66,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "amd64",
-            "version": "5.1.50905.0"
+            "version": "5.1.50905.0",
             "urls": [
                 "https://download.microsoft.com/download/8/6/A/86AC5F63-A0C9-4868-8CC5-C653B189E4B6/50905.00/Silverlight_x64.exe",
             ],
@@ -74,7 +74,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "x86",
-            "version": "5.1.50906.0"
+            "version": "5.1.50906.0",
             "urls": [
                 "https://download.microsoft.com/download/3/F/5/3F5B3DEC-A698-4B6A-8BB9-A1A554EA103C/50906.00/Silverlight.exe",
             ],
@@ -82,7 +82,7 @@ class Silverlight(Dependency):
         },
         {
             "arch": "amd64",
-            "version": "5.1.50906.0"
+            "version": "5.1.50906.0",
             "urls": [
                 "https://download.microsoft.com/download/3/F/5/3F5B3DEC-A698-4B6A-8BB9-A1A554EA103C/50906.00/Silverlight_x64.exe",
             ],

--- a/vmcloak/dependencies/vcredist.py
+++ b/vmcloak/dependencies/vcredist.py
@@ -23,6 +23,7 @@ class VcRedist(Dependency):
 
     exes = [
         {
+            # 6.00.2900.2180
             "version": "2005",
             "arch": "x86",
             "urls": [
@@ -39,6 +40,7 @@ class VcRedist(Dependency):
             "sha1": "90a3d2a139c1a106bfccd98cbbd7c2c1d79f5ebe"
         },
         {
+            # 6.00.3790.0
             "version": "2005sp1",
             "arch": "x86",
             "urls": [
@@ -57,20 +59,24 @@ class VcRedist(Dependency):
             "sha1": "756f2c773d4733e3955bf7d8f1e959a7f5634b1a"
         },
         {
+            # 9.0.21022.08
             "version": "2008",
             "arch": "x86",
             "urls": [
-                "https://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe",
+                "https://download.microsoft.com/download/1/1/1/1116b75a-9ec3-481a-a3c8-1777b5381140/vcredist_x86.exe",
             ],
             "sha1": "56719288ab6514c07ac2088119d8a87056eeb94a"
         },
         {
             "version": "2008",
             "arch": "amd64",
-            "url": "https://download.microsoft.com/download/d/2/4/d242c3fb-da5a-4542-ad66-f9661d0a8d19/vcredist_x64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/d/2/4/d242c3fb-da5a-4542-ad66-f9661d0a8d19/vcredist_x64.exe",
+            ],
             "sha1": "5580072a056fdd50cdf93d470239538636f8f3a9"
         },
         {
+            # 9.0.30729.17
             "version": "2008sp1",
             "arch": "x86",
             "urls": [
@@ -89,6 +95,7 @@ class VcRedist(Dependency):
             "sha1": "13674c43652b941dafd2049989afce63cb7c517b"
         },
         {
+            # 10.0.30319.01
             "version": "2010",
             "arch": "x86",
             "urls": [
@@ -105,6 +112,7 @@ class VcRedist(Dependency):
             "sha1": "b330b760a8f16d5a31c2dc815627f5eb40861008"
         },
         {
+            # 10.0.40219.01
             "version": "2010sp1",
             "arch": "x86",
             "urls": [
@@ -123,6 +131,55 @@ class VcRedist(Dependency):
             "sha1": "027d0c2749ec5eb21b031f46aee14c905206f482"
         },
         {
+            # 11.0.50727.1
+            "version": "2012",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/vcredist_x86.exe",
+            ],
+            "sha1": "407951838ef622bbfd2e359f0019453dc9a124ed"
+        },
+        {
+            "version": "2012",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/vcredist_x64.exe",
+            ],
+            "sha1": "60727ca083e3625a76c3edbba22b40d8a35ffd6b"
+        },
+        {
+            "version": "2012u1",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU1/vcredist_x86.exe",
+            ],
+            "sha1": "d292afddbae41acb2a1dfe647e15336ad7375c6f"
+        },
+        {
+            "version": "2012u1",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU1/vcredist_x64.exe",
+            ],
+            "sha1": "abe47e4996cf0409a794c1844f1fa8404032edb2"
+        },
+        {
+            "version": "2012u3",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU3/vcredist_x86.exe",
+            ],
+            "sha1": "7d6f654c16f9ce534bb2c4b1669d7dc039c433c9"
+        },
+        {
+            "version": "2012u3",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU3/vcredist_x64.exe",
+            ],
+            "sha1": "c4ac45564e801e1bfd87936cac8a76c5754cdbd4"
+        },
+        {
             "version": "2012u4",
             "arch": "x86",
             "urls": [
@@ -139,6 +196,7 @@ class VcRedist(Dependency):
             "sha1": "1a5d93dddbc431ab27b1da711cd3370891542797"
         },
         {
+            # 12.0.30501.0
             "version": "2013",
             "arch": "x86",
             "urls": [
@@ -157,10 +215,30 @@ class VcRedist(Dependency):
             "sha1": "8bf41ba9eef02d30635a10433817dbb6886da5a2"
         },
         {
+            # 12.0.40649.0
+            # https://support.microsoft.com/en-us/help/3138367/update-for-visual-c-2013-and-visual-c-redistributable-package
+            "version": "2013u4",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/c/c/2/cc2df5f8-4454-44b4-802d-5ea68d086676/vcredist_x86.exe",
+            ],
+            "sha1": "a2889d057d63da00f2f8ab9c4ed1e127bdf5db68"
+        },
+        {
+            "version": "2013u4",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/c/c/2/cc2df5f8-4454-44b4-802d-5ea68d086676/vcredist_x64.exe",
+            ],
+            "sha1": "c990b86c2f8064c53f1de8c0bffe2d1c463aaa88"
+        },
+        {
+            # 12.0.40660.0
+            # https://support.microsoft.com/en-us/help/3179560/update-for-visual-c-2013-and-visual-c-redistributable-package
             "version": "2013u5",
             "arch": "x86",
             "urls": [
-                "http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe",
+                "https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe",
             ],
             "sha1": "2a07a32330d5131665378836d542478d3e7bd137"
         },
@@ -168,11 +246,12 @@ class VcRedist(Dependency):
             "version": "2013u5",
             "arch": "amd64",
             "urls": [
-                "http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe",
+                "https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe",
             ],
             "sha1": "261c2e77d288a513a9eb7849cf5afca6167d4fa2"
         },
         {
+            # 14.0.23026.0
             "version": "2015",
             "arch": "x86",
             "urls": [
@@ -191,6 +270,41 @@ class VcRedist(Dependency):
             "sha1": "3155cb0f146b927fcc30647c1a904cd162548c8c"
         },
         {
+            # 14.0.24212.0
+            "version": "2015u1",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/6/D/F/6DF3FF94-F7F9-4F0B-838C-A328D1A7D0EE/vc_redist.x86.exe",
+            ],
+            "sha1": "89f20df555625e1796a60bba0fbd2f6bbc627370"
+        },
+        {
+            "version": "2015u1",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/6/D/F/6DF3FF94-F7F9-4F0B-838C-A328D1A7D0EE/vc_redist.x64.exe",
+            ],
+            "sha1": "cd2fce1bf61637b2536b66ee52a9662473bbdc82"
+        },
+        {
+            # 14.0.24123.0
+            "version": "2015u2",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/0/6/4/064F84EA-D1DB-4EAA-9A5C-CC2F0FF6A638/vc_redist.x86.exe",
+            ],
+            "sha1": "e99e5b17b0ad882833bbdc8cf798dc56f9947a5e"
+        },
+        {
+            "version": "2015u2",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/0/6/4/064F84EA-D1DB-4EAA-9A5C-CC2F0FF6A638/vc_redist.x64.exe",
+            ],
+            "sha1": "ff15c4f5da3c54f88676e6b44f3314b173835c28"
+        },
+        {
+            # 14.0.24215.1
             "version": "2015u3",
             "arch": "x86",
             "urls": [

--- a/vmcloak/dependencies/vcredist.py
+++ b/vmcloak/dependencies/vcredist.py
@@ -4,10 +4,13 @@
 
 from vmcloak.abstract import Dependency
 
+
 class VcRedist(Dependency):
+    # all latest versions can be found on:
+    # https://support.microsoft.com/en-us/kb/2977003
     name = "vcredist"
     description = "Visual studio redistributable packages"
-    default = "2005"
+    default = "2005sp1"
 
     install_params = {
         "2005": "/q:a",
@@ -22,81 +25,193 @@ class VcRedist(Dependency):
         {
             "version": "2005",
             "arch": "x86",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2005_x86.exe",
-            "sha1": "7dfa98be78249921dd0eedb9a3dd809e7d215c8d"
+            "urls": [
+                "https://download.microsoft.com/download/d/3/4/d342efa6-3266-4157-a2ec-5174867be706/vcredist_x86.exe",
+            ],
+            "sha1": "47fba37de95fa0e2328cf2e5c8ebb954c4b7b93c"
         },
         {
             "version": "2005",
             "arch": "amd64",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2005_x64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/9/1/4/914851c6-9141-443b-bdb4-8bad3a57bea9/vcredist_x64.exe",
+            ],
+            "sha1": "90a3d2a139c1a106bfccd98cbbd7c2c1d79f5ebe"
+        },
+        {
+            "version": "2005sp1",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/e/1/c/e1c773de-73ba-494a-a5ba-f24906ecf088/vcredist_x86.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2005_x86.exe",
+            ],
+            "sha1": "7dfa98be78249921dd0eedb9a3dd809e7d215c8d"
+        },
+        {
+            "version": "2005sp1",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/d/4/1/d41aca8a-faa5-49a7-a5f2-ea0aa4587da0/vcredist_x64.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2005_x64.exe",
+            ],
             "sha1": "756f2c773d4733e3955bf7d8f1e959a7f5634b1a"
         },
         {
             "version": "2008",
             "arch": "x86",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2008_x86.exe",
-            "sha1": "6939100e397cef26ec22e95e53fcd9fc979b7bc9"
+            "urls": [
+                "https://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe",
+            ],
+            "sha1": "56719288ab6514c07ac2088119d8a87056eeb94a"
         },
         {
             "version": "2008",
             "arch": "amd64",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2008_x64.exe",
+            "url": "https://download.microsoft.com/download/d/2/4/d242c3fb-da5a-4542-ad66-f9661d0a8d19/vcredist_x64.exe",
+            "sha1": "5580072a056fdd50cdf93d470239538636f8f3a9"
+        },
+        {
+            "version": "2008sp1",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2008_x86.exe",
+            ],
+            "sha1": "6939100e397cef26ec22e95e53fcd9fc979b7bc9"
+        },
+        {
+            "version": "2008sp1",
+            "arch": "amd64",
+            "urls": [
+                "https://cuckoo.sh/vmcloak/vcredist_2008_x64.exe",
+                "https://download.microsoft.com/download/2/d/6/2d61c766-107b-409d-8fba-c39e61ca08e8/vcredist_x64.exe",
+            ],
             "sha1": "13674c43652b941dafd2049989afce63cb7c517b"
         },
         {
             "version": "2010",
             "arch": "x86",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2010_x86.exe",
-            "sha1": "b84b83a8a6741a17bfb5f3578b983c1de512589d"
+            "urls": [
+                "https://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe",
+            ],
+            "sha1": "372d9c1670343d3fb252209ba210d4dc4d67d358"
         },
         {
             "version": "2010",
             "arch": "amd64",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2010_x64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe",
+            ],
+            "sha1": "b330b760a8f16d5a31c2dc815627f5eb40861008"
+        },
+        {
+            "version": "2010sp1",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2010_x86.exe",
+            ],
+            "sha1": "b84b83a8a6741a17bfb5f3578b983c1de512589d"
+        },
+        {
+            "version": "2010sp1",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2010_x64.exe",
+            ],
             "sha1": "027d0c2749ec5eb21b031f46aee14c905206f482"
         },
         {
-            "version": "2012",
+            "version": "2012u4",
             "arch": "x86",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2012_x86.exe",
-            "sha1": "7d6f654c16f9ce534bb2c4b1669d7dc039c433c9"
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe",
+            ],
+            "sha1": "96b377a27ac5445328cbaae210fc4f0aaa750d3f"
         },
         {
-            "version": "2012",
+            "version": "2012u4",
             "arch": "amd64",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2012_x64.exe",
-            "sha1": "c4ac45564e801e1bfd87936cac8a76c5754cdbd4"
+            "urls": [
+                "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe",
+            ],
+            "sha1": "1a5d93dddbc431ab27b1da711cd3370891542797"
         },
         {
             "version": "2013",
             "arch": "x86",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2013_x86.exe",
+            "urls": [
+                "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2013_x86.exe",
+            ],
             "sha1": "df7f0a73bfa077e483e51bfb97f5e2eceedfb6a3"
         },
         {
             "version": "2013",
             "arch": "amd64",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2013_x64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2013_x64.exe",
+            ],
             "sha1": "8bf41ba9eef02d30635a10433817dbb6886da5a2"
+        },
+        {
+            "version": "2013u5",
+            "arch": "x86",
+            "urls": [
+                "http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe",
+            ],
+            "sha1": "2a07a32330d5131665378836d542478d3e7bd137"
+        },
+        {
+            "version": "2013u5",
+            "arch": "amd64",
+            "urls": [
+                "http://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe",
+            ],
+            "sha1": "261c2e77d288a513a9eb7849cf5afca6167d4fa2"
         },
         {
             "version": "2015",
             "arch": "x86",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2015_x86.exe",
+            "urls": [
+                "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2015_x86.exe",
+            ],
             "sha1": "bfb74e498c44d3a103ca3aa2831763fb417134d1"
         },
         {
             "version": "2015",
             "arch": "amd64",
-            "url": "https://cuckoo.sh/vmcloak/vcredist_2015_x64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe",
+                "https://cuckoo.sh/vmcloak/vcredist_2015_x64.exe",
+            ],
             "sha1": "3155cb0f146b927fcc30647c1a904cd162548c8c"
+        },
+        {
+            "version": "2015u3",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x86.exe",
+            ],
+            "sha1": "72211bd2e7dfc91ea7c8fac549c49c0543ba791b"
+        },
+        {
+            "version": "2015u3",
+            "arch": "amd64",
+            "urls": [
+                "https://download.microsoft.com/download/6/A/A/6AA4EDFF-645B-48C5-81CC-ED5963AEAD48/vc_redist.x64.exe",
+            ],
+            "sha1": "10b1683ea3ff5f36f225769244bf7e7813d54ad0"
         },
     ]
 
     def run(self):
         # Get the installation parameters required to start
         # an unattended install
-        param = self.install_params[self.version]
+        param = self.install_params[self.version.split("u")[0].split("sp")[0]]
 
         self.upload_dependency("C:\\vcredist.exe")
         self.a.execute("C:\\vcredist.exe %s" % param)

--- a/vmcloak/dependencies/wic.py
+++ b/vmcloak/dependencies/wic.py
@@ -22,7 +22,7 @@ class WIC(Dependency):
             "sha1": "53c18652ac2f8a51303deb48a1b7abbdb1db427f",
         },
         {
-            "arch": "x64",
+            "arch": "amd64",
             "urls": [
                 "https://download.microsoft.com/download/6/4/5/645FED5F-A6E7-44D9-9D10-FE83348796B0/wic_x64_enu.exe",
             ],

--- a/vmcloak/dependencies/wic.py
+++ b/vmcloak/dependencies/wic.py
@@ -1,21 +1,33 @@
 # Copyright (C) 2014-2015 Jurriaan Bremer.
 # This file is part of VMCloak - http://www.vmcloak.org/.
 # See the file 'docs/LICENSE.txt' for copying permission.
-# 
-# The Windows Imaging Component (WIC) provides WIC-enabled 
+#
+# The Windows Imaging Component (WIC) provides WIC-enabled
 # applications to display and edit any image format for which
-# a WIC-compliant CODEC is installed, and also to read and 
-# write metadata in image files. 
+# a WIC-compliant CODEC is installed, and also to read and
+# write metadata in image files.
 
 from vmcloak.abstract import Dependency
+
 
 class WIC(Dependency):
     name = "wic"
     exes = [
         {
-            "url": "https://cuckoo.sh/vmcloak/wic_x86_enu.exe",
+            "arch": "x86",
+            "urls": [
+                "https://download.microsoft.com/download/f/f/1/ff178bb1-da91-48ed-89e5-478a99387d4f/wic_x86_enu.exe",
+                "https://cuckoo.sh/vmcloak/wic_x86_enu.exe",
+            ],
             "sha1": "53c18652ac2f8a51303deb48a1b7abbdb1db427f",
         },
+        {
+            "arch": "x64",
+            "urls": [
+                "https://download.microsoft.com/download/6/4/5/645FED5F-A6E7-44D9-9D10-FE83348796B0/wic_x64_enu.exe",
+            ],
+            "sha1": "4bdbf76a7bc96453306c893b4a7b2b8ae6127f67",
+        }
     ]
 
     def run(self):

--- a/vmcloak/dependencies/win7sp.py
+++ b/vmcloak/dependencies/win7sp.py
@@ -8,15 +8,21 @@ class Win7sp(Dependency):
     name = "win7sp"
     exes = [
         {
-            "version": "1",
+            "version": "sp1",
             "target": "win7x64",
-            "url": "https://cuckoo.sh/vmcloak/windows6.1-KB976932-X64.exe",
+            "urls": [
+                "https://download.microsoft.com/download/0/A/F/0AFB5316-3062-494A-AB78-7FB0D4461357/windows6.1-KB976932-X64.exe",
+                "https://cuckoo.sh/vmcloak/windows6.1-KB976932-X64.exe",
+            ],
             "sha1": "74865ef2562006e51d7f9333b4a8d45b7a749dab",
         },
         {
-            "version": "1",
+            "version": "sp1",
             "target": "win7x86",
-            "url": "https://cuckoo.sh/vmcloak/windows6.1-KB976932-X86.exe",
+            "urls": [
+                "https://download.microsoft.com/download/0/A/F/0AFB5316-3062-494A-AB78-7FB0D4461357/windows6.1-KB976932-X86.exe",
+                "https://cuckoo.sh/vmcloak/windows6.1-KB976932-X86.exe",
+            ],
             "sha1": "c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa",
         },
     ]

--- a/vmcloak/dependencies/winrar.py
+++ b/vmcloak/dependencies/winrar.py
@@ -9,14 +9,38 @@ class Winrar(Dependency):
     default = "5.31"
     exes = [
         {
-            "version": "5.31_x64",
-            "url": "https://cuckoo.sh/vmcloak/winrar-x64-531.exe",
+            "version": "5.31",
+            "arch": "amd64",
+            "urls": [
+                "http://rarlab.com/rar/winrar-x64-531.exe",
+                "https://cuckoo.sh/vmcloak/winrar-x64-531.exe",
+            ],
             "sha1": "48add5a966ed940c7d88456caf7a5f5c2a6c27a7",
         },
         {
             "version": "5.31",
-            "url": "https://cuckoo.sh/vmcloak/wrar531.exe",
+            "arch": "x86",
+            "urls": [
+                "http://rarlab.com/rar/wrar531.exe"
+                "https://cuckoo.sh/vmcloak/wrar531.exe",
+            ],
             "sha1": "e19805a1738975aeec19a25a4e461d52eaf9b231",
+        },
+        {
+            "version": "5.40",
+            "arch": "amd64",
+            "urls": [
+                "http://rarlab.com/rar/winrar-x64-540.exe",
+            ],
+            "sha1": "22ac3a032f37ce5dabd0673f401f3d0307f21b74",
+        },
+        {
+            "version": "5.40",
+            "arch": "x86",
+            "urls": [
+                "http://rarlab.com/rar/wrar540.exe"
+            ],
+            "sha1": "211a19ca4ec3c7562c9844fe6c42e66a521b8bd4",
         },
     ]
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -126,6 +126,7 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
+        vrde = True
         log.setLevel(logging.DEBUG)
 
     session = Session()
@@ -264,10 +265,12 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
 @click.argument("name")
 @click.argument("dependencies", nargs=-1)
 @click.option("--vm-visible", is_flag=True)
+@click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
 @click.option("-r", "--recommended", is_flag=True, help="Install recommended packages.")
 @click.option("-d", "--debug", is_flag=True, help="Install applications in debug mode.")
-def install(name, dependencies, vm_visible, recommended, debug):
+def install(name, dependencies, vm_visible, vrde, recommended, debug):
     if debug:
+        vrde = True
         log.setLevel(logging.DEBUG)
 
     session = Session()
@@ -286,6 +289,8 @@ def install(name, dependencies, vm_visible, recommended, debug):
     m, h = initvm(image)
 
     if image.vm == "virtualbox":
+        if vrde:
+            m.vrde()
         m.start_vm(visible=vm_visible)
 
     wait_for_host(image.ipaddr, image.port)
@@ -371,7 +376,13 @@ def install(name, dependencies, vm_visible, recommended, debug):
 @main.command()
 @click.argument("name")
 @click.option("--vm-visible", is_flag=True)
-def modify(name, vm_visible):
+@click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
+@click.option("-d", "--debug", is_flag=True, help="Install applications in debug mode.")
+def modify(name, vm_visible, vrde, debug):
+    if debug:
+        vrde = True
+        log.setLevel(logging.DEBUG)
+
     session = Session()
 
     image = session.query(Image).filter_by(name=name).first()
@@ -387,6 +398,8 @@ def modify(name, vm_visible):
 
     m, h = initvm(image)
 
+    if vrde:
+        m.vrde()
     m.start_vm(visible=vm_visible)
     wait_for_host(image.ipaddr, image.port)
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -117,12 +117,13 @@ def clone(name, outname):
 @click.option("--resolution", default="1024x768", help="Screen resolution.")
 @click.option("--vm-visible", is_flag=True, help="Start the Virtual Machine in GUI mode.")
 @click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
+@click.option("--vrde-port", default=3389, help="Specify the VRDE port.")
 @click.option("-d", "--debug", is_flag=True, help="Install Virtual Machine in debug mode.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
          win10x64, product, vm, iso_mount, serial_key, ip, port, adapter,
          netmask, gateway, dns, cpus, ramsize, vramsize, tempdir, resolution,
-         vm_visible, vrde, debug, verbose):
+         vm_visible, vrde, vrde_port, debug, verbose):
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
@@ -237,7 +238,7 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
         m.hostonly(nictype=h.nictype, adapter=adapter)
 
         if vrde:
-            m.vrde()
+            m.vrde(port=vrde_port)
 
         log.info("Starting the Virtual Machine %r to install Windows.", name)
         m.start_vm(visible=vm_visible)
@@ -266,9 +267,10 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
 @click.argument("dependencies", nargs=-1)
 @click.option("--vm-visible", is_flag=True)
 @click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
+@click.option("--vrde-port", default=3389, help="Specify the VRDE port.")
 @click.option("-r", "--recommended", is_flag=True, help="Install recommended packages.")
 @click.option("-d", "--debug", is_flag=True, help="Install applications in debug mode.")
-def install(name, dependencies, vm_visible, vrde, recommended, debug):
+def install(name, dependencies, vm_visible, vrde, vrde_port, recommended, debug):
     if debug:
         vrde = True
         log.setLevel(logging.DEBUG)
@@ -290,7 +292,7 @@ def install(name, dependencies, vm_visible, vrde, recommended, debug):
 
     if image.vm == "virtualbox":
         if vrde:
-            m.vrde()
+            m.vrde(port=vrde_port)
         m.start_vm(visible=vm_visible)
 
     wait_for_host(image.ipaddr, image.port)
@@ -377,8 +379,9 @@ def install(name, dependencies, vm_visible, vrde, recommended, debug):
 @click.argument("name")
 @click.option("--vm-visible", is_flag=True)
 @click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
+@click.option("--vrde-port", default=3389, help="Specify the VRDE port.")
 @click.option("-d", "--debug", is_flag=True, help="Install applications in debug mode.")
-def modify(name, vm_visible, vrde, debug):
+def modify(name, vm_visible, vrde, vrde_port, debug):
     if debug:
         vrde = True
         log.setLevel(logging.DEBUG)
@@ -399,7 +402,7 @@ def modify(name, vm_visible, vrde, debug):
     m, h = initvm(image)
 
     if vrde:
-        m.vrde()
+        m.vrde(port=vrde_port)
     m.start_vm(visible=vm_visible)
     wait_for_host(image.ipaddr, image.port)
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -26,7 +26,6 @@ from vmcloak.win81 import Windows81x86, Windows81x64
 from vmcloak.win10 import Windows10x86, Windows10x64
 from vmcloak.vm import VirtualBox
 from vmcloak.constants import VMCLOAK_VM_MODES
-from vmcloak.abstract import wait_process_exit
 
 logging.basicConfig()
 log = logging.getLogger("vmcloak")
@@ -467,13 +466,13 @@ def do_snapshot(image, vmname, ipaddr, resolution, ramsize, cpus,
 
     if interactive:
         a.upload("C:\\vmcloak\\interactive.txt",
-            "Please make your final changes to this VM. When you're done, close this window and we'll create a snapshot.")
-        a.execute("notepad.exe C:\\vmcloak\\interactive.txt")
+                 "Please make your final changes to this VM. When you're"
+                 "done, close this window and we'll create a snapshot.")
 
-        log.info("You've started the snapshot creation in interactive mode.")
+        log.info("You've started the snapshot creation in interactive mode!")
         log.info("Please make your last changes to the VM.")
-        log.info("When you're done close the spawned notepad process in the VM to take a snapshot.")
-        wait_process_exit("notepad.exe")
+        log.info("When you're done close the spawned notepad process in the VM to take the final snapshot.")
+        a.execute("notepad.exe C:\\vmcloak\\interactive.txt", async=False)
 
     a.remove("C:\\vmcloak")
     m.snapshot("vmcloak", "Snapshot created by VM Cloak.")

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -116,12 +116,13 @@ def clone(name, outname):
 @click.option("--tempdir", default=iso_dst_path, help="Temporary directory to build the ISO file.")
 @click.option("--resolution", default="1024x768", help="Screen resolution.")
 @click.option("--vm-visible", is_flag=True, help="Start the Virtual Machine in GUI mode.")
+@click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
 @click.option("-d", "--debug", is_flag=True, help="Install Virtual Machine in debug mode.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
          win10x64, product, vm, iso_mount, serial_key, ip, port, adapter,
          netmask, gateway, dns, cpus, ramsize, vramsize, tempdir, resolution,
-         vm_visible, debug, verbose):
+         vm_visible, vrde, debug, verbose):
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
@@ -233,6 +234,9 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
         m.create_hd(hdd_path)
         m.attach_iso(iso_path)
         m.hostonly(nictype=h.nictype, adapter=adapter)
+
+        if vrde:
+            m.vrde()
 
         log.info("Starting the Virtual Machine %r to install Windows.", name)
         m.start_vm(visible=vm_visible)

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -118,12 +118,13 @@ def clone(name, outname):
 @click.option("--vm-visible", is_flag=True, help="Start the Virtual Machine in GUI mode.")
 @click.option("--vrde", is_flag=True, help="Enable the VirtualBox Remote Display Protocol.")
 @click.option("--vrde-port", default=3389, help="Specify the VRDE port.")
+@click.option("--python-version", default="2.7.6", help="Which Python version do we install on the guest?")
 @click.option("-d", "--debug", is_flag=True, help="Install Virtual Machine in debug mode.")
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
          win10x64, product, vm, iso_mount, serial_key, ip, port, adapter,
          netmask, gateway, dns, cpus, ramsize, vramsize, tempdir, resolution,
-         vm_visible, vrde, vrde_port, debug, verbose):
+         vm_visible, vrde, vrde_port, python_version, debug, verbose):
     if verbose:
         log.setLevel(logging.INFO)
     if debug:
@@ -195,7 +196,7 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
     os.mkdir(vmcloak_dir)
 
     # Download the Python dependency and set it up for bootstrapping the VM.
-    d = Python(i=Image(osversion=osversion))
+    d = Python(i=Image(osversion=osversion), version=python_version)
     d.download()
     shutil.copy(d.filepath, vmcloak_dir)
 

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -196,7 +196,7 @@ def init(name, winxp, win7x86, win7x64, win81x86, win81x64, win10x86,
     os.mkdir(vmcloak_dir)
 
     # Download the Python dependency and set it up for bootstrapping the VM.
-    d = Python(i=Image(osversion=osversion), version=python_version)
+    d = Python(i=Image(osversion=osversion), h=h, version=python_version)
     d.download()
     shutil.copy(d.filepath, vmcloak_dir)
 

--- a/vmcloak/misc.py
+++ b/vmcloak/misc.py
@@ -278,3 +278,28 @@ def ipaddr_increase(ipaddr):
 def filename_from_url(url):
     """Return the filename from a given url."""
     return os.path.basename(urllib2.urlparse.urlparse(url).path)
+
+
+def download_file(url, filepath):
+    """Download the file from url and store it in the given filepath."""
+    user_agent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko'
+    headers = {'User-Agent': user_agent}
+
+    req = urllib2.Request(url=url, headers=headers)
+
+    try:
+        log.debug("Opening connection to '{}'".format(url))
+        t0 = time.time()
+        res = urllib2.urlopen(req).read()
+        t1 = time.time()
+    except urllib2.URLError as e:
+        log.warn("Failed to download file from '{}', got error: '{}'".format(url, e))
+        return False
+
+    fname = filename_from_url(url)
+    size = len(res)
+    msize = size / 1000.0 / 1000
+    log.debug("Succesfully downloaded file '{}' ({:.2f}MB) from '{}' in '{:.2f}' second(s) ({:.2f}MB/s)".format(
+        fname, msize, url, t1 - t0, msize / (t1 - t0)))
+    with open(filepath, "wb") as f:
+        f.write(res)

--- a/vmcloak/misc.py
+++ b/vmcloak/misc.py
@@ -13,6 +13,7 @@ import struct
 import subprocess
 import sys
 import time
+import urllib2
 
 from ConfigParser import ConfigParser
 
@@ -272,3 +273,8 @@ def ipaddr_increase(ipaddr):
     """Increases the IP address."""
     addr = struct.unpack(">I", socket.inet_aton(ipaddr))[0]
     return socket.inet_ntoa(struct.pack(">I", addr + 1))
+
+
+def filename_from_url(url):
+    """Return the filename from a given url."""
+    return os.path.basename(urllib2.urlparse.urlparse(url).path)

--- a/vmcloak/misc.py
+++ b/vmcloak/misc.py
@@ -12,6 +12,7 @@ import stat
 import struct
 import subprocess
 import sys
+import time
 
 from ConfigParser import ConfigParser
 
@@ -224,11 +225,12 @@ def wait_for_host(ipaddr, port):
     # Wait for the Agent to come up with a timeout of 1 second.
     while True:
         try:
-            log.debug("Waiting for host %s", ipaddr)
             socket.create_connection((ipaddr, port), 1).close()
             break
         except socket.error:
+            log.debug("Waiting for host %s", ipaddr)
             pass
+        time.sleep(1)
 
 def drop_privileges(user):
     if not HAVE_PWD:

--- a/vmcloak/vm.py
+++ b/vmcloak/vm.py
@@ -221,7 +221,7 @@ class VirtualBox(Machinery):
     def mouse(self, type):
         return self._call("modifyvm", self.name, mouse=type)
 
-    def vrde(self, port, password):
+    def vrde(self, port=3389, password=""):
         return self._call("modifyvm", self.name, vrde="on", vrdeport=port,
                           vrdeproperty="VNCPassword=%s" % password)
 


### PR DESCRIPTION
- One can now use the --vrde flag in vmcloak to enable the VirtualBox Remote Desktop Extension (VRDE) option in VirtualBox. This can be used to monitor the progress in the VM or to make modifications when running vmcloak modify.
- Allow multiple urls per dependency. Try the official url (if available) first and use the cuckoo.sh as a backup link.
- Rewrote the downloader to stop using a syscall to wget. Now using urllib2.
- Added support for Adobe Reader newer than version 11.0.11. These use a MSI update/patch package.
- Added more versions to vceredist and dotnet framework.
- Added support for a "latest" version, if there is a (dynamic) direct link to the latest version.