### PR TITLE
Dependency to enable PowerShell script block logging 

### DIFF
--- a/vmcloak/dependencies/kb.py
+++ b/vmcloak/dependencies/kb.py
@@ -117,6 +117,30 @@ class KB(Dependency):
             "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2888049-x86.msu",
             "sha1": "65b4c7a5773fab177d20c8e49d773492e55e8d76",
         },
+        {
+            "version": "2819745",
+            "target": "win7x64",
+            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2819745-x64-MultiPkg.msu",
+            "sha1": "5d40d059b9ea7f1d596f608a07cca49e4537dc15",
+        },
+        {
+            "version": "2819745",
+            "target": "win7x86",
+            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB2819745-x86-MultiPkg.msu",
+            "sha1": "378bd9f96b8c898b86bb0c0b92f2c9c000748c5e",
+        },
+        {
+            "version": "3109118",
+            "target": "win7x64",
+            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB3109118-v4-x64.msu",
+            "sha1": "ae0cac3e0571874dbc963dabbfa7d17d45db582c",
+        },
+        {
+            "version": "3109118",
+            "target": "win7x86",
+            "url": "https://cuckoo.sh/vmcloak/Windows6.1-KB3109118-v4-x86.msu",
+            "sha1": "378bd9f96b8c898b86bb0c0b92f2c9c000748c5e",
+        },
     ]
 
     def run(self):

--- a/vmcloak/dependencies/ps1logging.py
+++ b/vmcloak/dependencies/ps1logging.py
@@ -6,8 +6,8 @@ import time
 
 from vmcloak.abstract import Dependency
 
-class PSLogging(Dependency):
-    name = "pslogging"
+class PS1Logging(Dependency):
+    name = "ps1logging"
     default = "3109118"
     depends = [
         "win7sp", "dotnet:4.6.1", "kb:2819745", "kb:3109118"

--- a/vmcloak/dependencies/pslogging.py
+++ b/vmcloak/dependencies/pslogging.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2014-2016 Jurriaan Bremer.
+# This file is part of VMCloak - http://www.vmcloak.org/.
+# See the file 'docs/LICENSE.txt' for copying permission.
+
+import time
+
+from vmcloak.abstract import Dependency
+
+class PSLogging(Dependency):
+    name = "pslogging"
+    default = "3109118"
+    depends = [
+        "win7sp", "dotnet:4.6.1", "kb:2819745", "kb:3109118"
+    ]
+
+    def run(self):
+        # Set registry keys to enable PowerShell enchanced logging
+
+        # Enable Module Logging for all modules
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Microsoft\\Windows\\PowerShell\\ModuleLogging\" "
+            "/v EnableModuleLogging /t REG_DWORD /d 00000001 /f /reg:64"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Microsoft\\Windows\\PowerShell\\ModuleLogging\\ModuleNames\" "
+            "/v * /t REG_SZ /d * /f /reg:64"
+        )
+
+        # Enable Script Block Logging
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\" "
+            "/v EnableScriptBlockLogging /t REG_DWORD /d 00000001 /f /reg:64"
+        )
+
+        # Enable Transcription and log to a central location
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Microsoft\\Windows\\PowerShell\\Transcription\" "
+            "/v EnableTranscripting /t REG_DWORD /d 00000001 /f /reg:64"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Microsoft\\Windows\\PowerShell\\Transcription\" "
+            "/v OutputDirectory /t REG_SZ /d \"C:\PSTranscipts\" /f /reg:64"
+        )
+        self.a.execute(
+            "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\"
+            "Policies\\Microsoft\\Windows\\PowerShell\\Transcription\" "
+            "/v EnableInvocationHeader /t REG_DWORD /d 00000001 /f /reg:64"
+        )

--- a/vmcloak/dependencies/win7sp.py
+++ b/vmcloak/dependencies/win7sp.py
@@ -6,6 +6,7 @@ from vmcloak.abstract import Dependency
 
 class Win7sp(Dependency):
     name = "win7sp"
+    default = "1"
     exes = [
         {
             "version": "1",

--- a/vmcloak/main.py
+++ b/vmcloak/main.py
@@ -334,6 +334,17 @@ def install(name, dependencies, vm_visible, recommended, debug):
                     else:
                         dversion = None
 
+                    if depend in dependencies:
+                        index = dependencies.index(depend)
+                        if dversion:
+                            log.error("You specified %s. "
+                                      "Will be reinstalling as: %s %s "
+                                      , dependencies[index], depend, dversion)
+                        else:
+                            log.error("You specified %s. "
+                                      "Will be reinstalling as: %s "
+                                      , dependencies[index], depend)
+
                     if dversion:
                         log.info("Installing child dependency %s %s..", depend, dversion)
                     else:


### PR DESCRIPTION
# What it does
Adds the ability to turn on PowerShell script block, module and transcript logging for windows 7 VM-s.

# Prerequisites
Requires Windows 7 SP1, .NET at least 4.5, 2 KB-s mentioned below
 
# Changes
## Added two required KB-s to the kb dependency:
- KB3109118 - Script block logging back port update for WMF4
- KB2819745 - WMF 4 (Windows Management Framework version 4) update for Windows 7

## Add default value for win7sp dependecy
Since it only has one option, a default seemed sensible, in order to not have to specify the version when declaring this as dependency

## New dependency pslogging
Declares dependencies and sets necessary registry keys to enable the logging functionality
