### PR TITLE
Fix Windows 10 installer hanging on builds >=1703.

### DIFF
--- a/vmcloak/data/win10/autounattend.xml
+++ b/vmcloak/data/win10/autounattend.xml
@@ -11,6 +11,8 @@
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
                 <NetworkLocation>Work</NetworkLocation>
                 <ProtectYourPC>3</ProtectYourPC>
+		        <SkipUserOOBE>true</SkipUserOOBE>
+		        <SkipMachineOOBE>true</SkipMachineOOBE>
             </OOBE>
             <AutoLogon>
                 <Enabled>true</Enabled>

--- a/vmcloak/data/win10/autounattend.xml
+++ b/vmcloak/data/win10/autounattend.xml
@@ -11,8 +11,8 @@
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
                 <NetworkLocation>Work</NetworkLocation>
                 <ProtectYourPC>3</ProtectYourPC>
-		        <SkipUserOOBE>true</SkipUserOOBE>
-		        <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
             </OOBE>
             <AutoLogon>
                 <Enabled>true</Enabled>


### PR DESCRIPTION
Fix Windows 10 builds 1703 and later (tested on 1803) getting stuck at Cortana configuration steps asking for the user to select a language and keyboard layout.