### PR TITLE
Bump Sysmon version to latest

### DIFF
--- a/vmcloak/dependencies/sysmon.py
+++ b/vmcloak/dependencies/sysmon.py
@@ -7,17 +7,17 @@ from vmcloak.abstract import Dependency
 class Sysmon(Dependency):
     name = "sysmon"
     description = "Monitoring and logging system activity"
-    default = "6.0.2"
+    default = "8.0.0"
     exes = [{
-        "version": "6.0.2",
+        "version": "8.0.0",
         "arch": "amd64",
         "url": "https://cuckoo.sh/vmcloak/Sysmon64.exe",
-        "sha1": "ce9edbea1937d593bf6cba4d9ca57d66f1680fdf",
+        "sha1": "173014bedc7d852a4cee961440ffaf06fa716353",
     }, {
-        "version": "6.0.2",
+        "version": "8.0.0",
         "arch": "x86",
         "url": "https://cuckoo.sh/vmcloak/Sysmon.exe",
-        "sha1": "b97d720eca991bd96d6a8d60ea93ee163e09178d",
+        "sha1": "8cc70223e7f667387d9792a5183129734d3b5501",
     }]
 
     def run(self):

--- a/vmcloak/dependencies/sysmon.py
+++ b/vmcloak/dependencies/sysmon.py
@@ -9,14 +9,24 @@ class Sysmon(Dependency):
     description = "Monitoring and logging system activity"
     default = "8.0.0"
     exes = [{
-        "version": "8.0.0",
+        "version": "6.0.2",
         "arch": "amd64",
         "url": "https://cuckoo.sh/vmcloak/Sysmon64.exe",
+        "sha1": "ce9edbea1937d593bf6cba4d9ca57d66f1680fdf",
+    }, {
+        "version": "6.0.2",
+        "arch": "x86",
+        "url": "https://cuckoo.sh/vmcloak/Sysmon.exe",
+        "sha1": "b97d720eca991bd96d6a8d60ea93ee163e09178d",
+    }, {
+        "version": "8.0.0",
+        "arch": "amd64",
+        "url": "https://cuckoo.sh/vmcloak/Sysmon64-8.0.0.exe",
         "sha1": "173014bedc7d852a4cee961440ffaf06fa716353",
     }, {
         "version": "8.0.0",
         "arch": "x86",
-        "url": "https://cuckoo.sh/vmcloak/Sysmon.exe",
+        "url": "https://cuckoo.sh/vmcloak/Sysmon-8.0.0.exe",
         "sha1": "8cc70223e7f667387d9792a5183129734d3b5501",
     }]
 


### PR DESCRIPTION
Install latest Sysmon version 8.0 instead of 6.0.2.

New executables need to be uploaded as https://cuckoo.sh/vmcloak/Sysmon64-8.0.0.exe and https://cuckoo.sh/vmcloak/Sysmon-8.0.0.exe

The new versions can be downloaded from: https://download.sysinternals.com/files/Sysmon.zip